### PR TITLE
Issue-24: Log > Add tracing / logging so that transactions submitted that don't match the Lamport clock are highlighted

### DIFF
--- a/lib/bedrock/data_plane/log/telemetry.ex
+++ b/lib/bedrock/data_plane/log/telemetry.ex
@@ -38,6 +38,29 @@ defmodule Bedrock.DataPlane.Log.Telemetry do
     )
   end
 
+  @spec trace_push_transaction(expected_version :: Bedrock.version(), n_keys :: non_neg_integer()) :: :ok
+  def trace_push_transaction(expected_version, n_keys) do
+    Telemetry.execute(
+      [:bedrock, :log, :push],
+      %{n_keys: n_keys},
+      Map.merge(trace_metadata(), %{
+        expected_version: expected_version
+      })
+    )
+  end
+
+  @spec trace_push_out_of_order(expected_version :: Bedrock.version(), current_version :: Bedrock.version()) :: :ok
+  def trace_push_out_of_order(expected_version, current_version) do
+    Telemetry.execute(
+      [:bedrock, :log, :push_out_of_order],
+      %{},
+      Map.merge(trace_metadata(), %{
+        expected_version: expected_version,
+        current_version: current_version
+      })
+    )
+  end
+
   @spec trace_pull_transactions(from_version :: Bedrock.version(), opts :: Keyword.t()) :: :ok
   def trace_pull_transactions(from_version, opts) do
     Telemetry.execute(

--- a/lib/bedrock/data_plane/log/tracing.ex
+++ b/lib/bedrock/data_plane/log/tracing.ex
@@ -11,6 +11,7 @@ defmodule Bedrock.DataPlane.Log.Tracing do
         [:bedrock, :log, :lock_for_recovery],
         [:bedrock, :log, :recover_from],
         [:bedrock, :log, :push],
+        [:bedrock, :log, :push_out_of_order],
         [:bedrock, :log, :pull]
       ],
       &__MODULE__.handler/4,
@@ -49,6 +50,10 @@ defmodule Bedrock.DataPlane.Log.Tracing do
 
   def log_event(:push, %{n_keys: n_keys}, %{expected_version: expected_version}) do
     info("Push transaction (#{n_keys} keys) with expected version #{inspect(expected_version)}")
+  end
+
+  def log_event(:push_out_of_order, _, %{expected_version: expected_version, current_version: current_version}) do
+    info("Rejected out-of-order transaction: expected #{inspect(expected_version)}, current #{inspect(current_version)}")
   end
 
   def log_event(:pull, _, %{from_version: from_version, opts: opts}),

--- a/test/bedrock/data_plane/log/telemetry_test.exs
+++ b/test/bedrock/data_plane/log/telemetry_test.exs
@@ -1,0 +1,60 @@
+defmodule Bedrock.DataPlane.Log.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Log.Telemetry
+
+  setup do
+    # Capture telemetry events
+    test_pid = self()
+    
+    :telemetry.attach_many(
+      "test-log-telemetry",
+      [
+        [:bedrock, :log, :push],
+        [:bedrock, :log, :push_out_of_order]
+      ],
+      &__MODULE__.handle_telemetry/4,
+      test_pid
+    )
+
+    # Set trace metadata for the process
+    Telemetry.trace_metadata(cluster: :test_cluster, id: "test_log", otp_name: :test_otp)
+
+    on_exit(fn ->
+      :telemetry.detach("test-log-telemetry")
+    end)
+
+    :ok
+  end
+
+  describe "trace_push_transaction/2" do
+    test "emits push telemetry event with correct data" do
+      expected_version = 42
+      n_keys = 5
+
+      Telemetry.trace_push_transaction(expected_version, n_keys)
+
+      assert_receive {:telemetry, [:bedrock, :log, :push], 
+                      %{n_keys: ^n_keys}, 
+                      %{expected_version: ^expected_version, cluster: :test_cluster, id: "test_log", otp_name: :test_otp}}
+    end
+  end
+
+  describe "trace_push_out_of_order/2" do
+    test "emits push_out_of_order telemetry event with version information" do
+      expected_version = 35
+      current_version = 42
+
+      Telemetry.trace_push_out_of_order(expected_version, current_version)
+
+      assert_receive {:telemetry, [:bedrock, :log, :push_out_of_order], 
+                      %{}, 
+                      %{expected_version: ^expected_version, current_version: ^current_version, 
+                        cluster: :test_cluster, id: "test_log", otp_name: :test_otp}}
+    end
+  end
+
+  def handle_telemetry(event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry, event, measurements, metadata})
+  end
+end


### PR DESCRIPTION
#24 