### PR TITLE
w84 - Fix strinc property test to only check equal-length keys

### DIFF
--- a/test/bedrock/key_test.exs
+++ b/test/bedrock/key_test.exs
@@ -223,10 +223,12 @@ defmodule Bedrock.KeyTest do
       end
     end
 
-    property "strinc preserves ordering (when both valid)" do
+    # strinc only preserves ordering for equal-length keys; prefix relationships break it.
+    property "strinc preserves ordering for equal-length keys" do
       check all(
-              key1 <- binary(min_length: 1, max_length: 50),
-              key2 <- binary(min_length: 1, max_length: 50)
+              len <- integer(1..50),
+              key1 <- binary(length: len),
+              key2 <- binary(length: len)
             ) do
         try do
           strinc1 = Key.strinc(key1)


### PR DESCRIPTION
strinc cannot preserve ordering when one key is a prefix of another - this is inherent to its prefix-range semantics. Updated the property test to generate equal-length keys where the ordering property holds.

Closes: bedrock-w84