### PR TITLE
Skip coveralls.github on scheduled CI runs

### DIFF
--- a/.github/workflows/elixir_ci.yaml
+++ b/.github/workflows/elixir_ci.yaml
@@ -84,7 +84,7 @@ jobs:
       run: mix dialyzer
 
     - name: Run tests
-      run: mix coveralls.github
+      run: ${{ github.event_name == 'schedule' && 'mix test' || 'mix coveralls.github' }}
 
   s3_test:
     if: github.event_name != 'schedule'


### PR DESCRIPTION
## Summary
- Work around excoveralls#280: `ExCoveralls.Github.git_info/0` crashes with `BadMapError` on schedule-triggered workflows because the GitHub event payload lacks actor info
- Use plain `mix test` for scheduled runs, keep `mix coveralls.github` for push/PR

## Test plan
- [ ] CI passes on this PR (push trigger → coveralls.github)
- [ ] Next Monday scheduled run should no longer fail