### PR TITLE
fix: restore persisted single-node restart recovery

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -54,10 +54,12 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
     :service_pids,
     :transaction_system_layout,
     :metadata_materializer,
-    :shard_layout
+    :shard_layout,
+    :shard_materializers
   ]
 
   @type shard_layout :: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}}
+  @type shard_materializers :: %{Bedrock.range_tag() => pid()}
 
   @type t :: %__MODULE__{
           attempt: non_neg_integer(),
@@ -79,7 +81,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           metadata_materializer: pid() | nil,
-          shard_layout: shard_layout() | nil
+          shard_layout: shard_layout() | nil,
+          shard_materializers: shard_materializers()
         }
 
   @doc """
@@ -116,7 +119,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       service_pids: %{},
       transaction_system_layout: nil,
       metadata_materializer: nil,
-      shard_layout: nil
+      shard_layout: nil,
+      shard_materializers: %{}
     }
   end
 end

--- a/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
@@ -14,6 +14,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
   With consistent hashing, shard→log mapping is computed (not stored), so per-shard quorum
   validation is no longer needed. Replacement logs can reconstruct their personalized transaction
   stream by pulling from all survivors and filtering by the shard index embedded in transactions.
+  The survivors remain recovery sources only; the new layout is rebuilt from fresh log vacancies
+  so replay targets always transition through `recover_from/4` before the system transaction.
 
   Stalls with `:unable_to_meet_log_quorum` if majority quorum cannot be established
   or no valid version range exists.
@@ -44,6 +46,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
           trace_recovery_suitable_logs_chosen(survivor_ids, version_vector)
 
           durable_version = calculate_durable_version(log_recovery_info)
+          old_logs = context.old_transaction_system_layout[:logs] || %{}
+          logs = recovery_layout_logs(old_logs, desired_logs(context), survivor_ids)
 
           updated_recovery_attempt =
             recovery_attempt
@@ -51,6 +55,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
             |> Map.put(:survivor_log_ids, survivor_ids)
             |> Map.put(:version_vector, version_vector)
             |> Map.put(:durable_version, durable_version)
+            |> Map.put(:logs, logs)
 
           {updated_recovery_attempt, Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase}
 
@@ -129,5 +134,29 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
     |> Enum.map(&Map.get(&1, :minimum_durable_version))
     |> Enum.reject(&(&1 == :unavailable))
     |> Enum.min(fn -> Version.zero() end)
+  end
+
+  defp survivor_logs(old_logs, survivor_ids) when is_map(old_logs) and is_list(survivor_ids) do
+    Map.take(old_logs, survivor_ids)
+  end
+
+  defp recovery_layout_logs(old_logs, desired_logs, survivor_ids) when is_map(old_logs) do
+    if consistent_hash_layout?(old_logs) do
+      1..desired_logs
+      |> Enum.map(&{:vacancy, &1})
+      |> Map.new(&{&1, []})
+    else
+      survivor_logs(old_logs, survivor_ids)
+    end
+  end
+
+  defp consistent_hash_layout?(old_logs) when map_size(old_logs) == 0, do: false
+
+  defp consistent_hash_layout?(old_logs) do
+    Enum.all?(old_logs, fn {_log_id, descriptor} -> descriptor == [] end)
+  end
+
+  defp desired_logs(context) do
+    get_in(context, [:cluster_config, :parameters, :desired_logs]) || 1
   end
 end

--- a/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
@@ -90,12 +90,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
       ) do
     copy_log_data_fn = Map.get(context, :copy_log_data_fn, &copy_log_data/5)
     service_pids = recovery_attempt.service_pids
+    replay_target_log_ids = replay_target_log_ids(new_log_ids, survivor_log_ids)
 
     # Build list of survivor PIDs from their IDs
     survivor_pids = Enum.map(survivor_log_ids, &Map.get(service_pids, &1))
     survivor_pids = Enum.reject(survivor_pids, &is_nil/1)
 
-    new_log_ids
+    replay_target_log_ids
     |> Task.async_stream(
       fn new_log_id ->
         new_log_id
@@ -123,6 +124,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
       failures when failures == %{} -> :ok
       failures -> {:error, {:failed_to_copy_some_logs, failures}}
     end
+  end
+
+  defp replay_target_log_ids(new_log_ids, survivor_log_ids) do
+    survivor_log_ids = MapSet.new(survivor_log_ids)
+    Enum.reject(new_log_ids, &MapSet.member?(survivor_log_ids, &1))
   end
 
   # Backward compatibility: delegate to new function

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -19,8 +19,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   2. If not found, create a new materializer on a capable node
   3. Lock materializer for recovery
   4. Unlock it with system shard logs to start pulling
-  5. Wait for materializer to catch up (60s timeout)
-  6. Query shard layout from `\\xff/system/shard_keys/*`
+  5. Wait for materializer to catch up to its durable baseline (60s timeout)
+  6. Poll shard layout reads from persisted `\\xff/system/shards/*` metadata until the
+     recovered layout version is actually readable
 
   Stalls if the materializer is unavailable and cannot be created, or if catchup
   times out. Transitions to CommitProxyStartupPhase with the materializer pid and
@@ -30,6 +31,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   use Bedrock.ControlPlane.Director.Recovery.RecoveryPhase
 
   import Bedrock, only: [end_of_keyspace: 0]
+  import Bedrock.ControlPlane.Config.ResolverDescriptor, only: [resolver_descriptor: 2]
 
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
@@ -37,12 +39,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   alias Bedrock.Internal.LayoutRouting
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.ShardMetadata
 
   require Logger
 
   # Catchup timeout: 60 seconds before stalling and retrying
   @catchup_timeout_ms 60_000
   @catchup_poll_interval_ms 500
+  @shard_layout_read_timeout_ms 5_000
 
   @impl true
   def execute(%RecoveryAttempt{} = recovery_attempt, context) do
@@ -183,54 +188,88 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   end
 
   defp handle_existing_cluster(recovery_attempt, context) do
-    # Read at the newest version determined during log recovery planning
     {_oldest, read_version} = recovery_attempt.version_vector
+    system_shard = RecoveryAttempt.system_shard_id()
 
     # Step 1-2: Find or create materializer for system shard
-    with {:ok, materializer_service} <- find_or_create_materializer(recovery_attempt, context),
+    with {:ok, materializer_service} <- find_or_create_materializer(recovery_attempt, context, system_shard),
          # Step 3: Lock for recovery
          {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
          # Step 4: Unlock with logs to start pulling
          :ok <- unlock_and_start_pulling(materializer_pid, recovery_attempt, context),
-         # Step 5: Wait for catchup
+         # Step 5: Wait for the durable baseline to become available
          :ok <- wait_for_materializer_catchup(materializer_pid, recovery_attempt.durable_version, context),
-         # Step 6: Query shard layout
+         # Step 6: Wait until shard layout reads succeed at the recovered read version
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, read_version, context) do
-      # Step 7: Continue
-      updated_attempt =
+      resolvers = resolver_descriptors_for_shard_layout(shard_layout)
+
+      recovery_attempt =
         recovery_attempt
         |> Map.put(:metadata_materializer, materializer_pid)
         |> Map.put(:shard_layout, shard_layout)
+        |> Map.put(:resolvers, resolvers)
 
-      {updated_attempt, CommitProxyStartupPhase}
+      case ensure_shard_materializers(recovery_attempt, materializer_pid, context) do
+        {:ok, shard_materializers} ->
+          updated_attempt = Map.put(recovery_attempt, :shard_materializers, shard_materializers)
+          {updated_attempt, CommitProxyStartupPhase}
+
+        {:error, reason} ->
+          {recovery_attempt, {:stalled, reason}}
+      end
     else
       {:error, reason} ->
         {recovery_attempt, {:stalled, reason}}
     end
   end
 
-  # Find existing materializer or create a new one for the system shard
-  defp find_or_create_materializer(recovery_attempt, context) do
-    case find_materializer_service(context) do
+  defp ensure_shard_materializers(recovery_attempt, metadata_materializer_pid, context) do
+    system_shard = RecoveryAttempt.system_shard_id()
+
+    recovery_attempt.shard_layout
+    |> extract_shard_tags()
+    |> Enum.reduce_while({:ok, %{system_shard => metadata_materializer_pid}}, fn shard_tag, {:ok, acc} ->
+      if shard_tag == system_shard do
+        {:cont, {:ok, acc}}
+      else
+        with {:ok, materializer_service} <- find_or_create_materializer(recovery_attempt, context, shard_tag),
+             {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
+             :ok <-
+               unlock_materializer_for_shard(
+                 materializer_pid,
+                 shard_tag,
+                 recovery_attempt,
+                 recovery_attempt.durable_version,
+                 context
+               ),
+             :ok <- wait_for_materializer_catchup(materializer_pid, recovery_attempt.durable_version, context) do
+          {:cont, {:ok, Map.put(acc, shard_tag, materializer_pid)}}
+        else
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end
+    end)
+  end
+
+  defp find_or_create_materializer(recovery_attempt, context, shard_tag) do
+    case find_materializer_service(context, shard_tag) do
       {:ok, service} ->
         {:ok, service}
 
       {:error, {:materializer_unavailable, :not_in_available_services}} ->
-        Logger.info("System shard materializer not found, creating new one")
-        create_materializer(recovery_attempt, context)
+        Logger.info("#{shard_label(shard_tag)} materializer not found, creating new one")
+        create_materializer(recovery_attempt, context, shard_tag)
     end
   end
 
-  # Find materializer assigned to system shard (tag 0)
-  # Supports both shard-based lookup (new format) and legacy string-key lookup
-  defp find_materializer_service(%{available_services: services}) do
-    system_shard = RecoveryAttempt.system_shard_id()
-
+  # Supports both shard-based lookup (new format) and legacy string-key lookup for tag 0.
+  defp find_materializer_service(%{available_services: services}, shard_tag) do
     # First try shard-based lookup (new format: {kind, ref, shard_id})
     shard_based_result =
       Enum.find(services, fn
         {_id, {kind, _ref, shard_id}} when is_integer(shard_id) ->
-          kind == :materializer and shard_id == system_shard
+          kind == :materializer and shard_id == shard_tag
 
         _ ->
           false
@@ -241,19 +280,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         {:ok, service}
 
       nil ->
-        # Fall back to legacy string-key lookup for backward compatibility
-        case Map.get(services, "metadata_materializer") do
-          nil -> {:error, {:materializer_unavailable, :not_in_available_services}}
-          service -> {:ok, service}
-        end
+        find_legacy_materializer_service(services, shard_tag)
     end
   end
 
-  # Create a new materializer on a capable node
-  defp create_materializer(recovery_attempt, context) do
+  defp find_legacy_materializer_service(services, shard_tag) do
+    if shard_tag == RecoveryAttempt.system_shard_id() do
+      case Map.get(services, "metadata_materializer") do
+        nil -> {:error, {:materializer_unavailable, :not_in_available_services}}
+        service -> {:ok, service}
+      end
+    else
+      {:error, {:materializer_unavailable, :not_in_available_services}}
+    end
+  end
+
+  defp create_materializer(recovery_attempt, context, shard_tag) do
     with {:ok, node} <- find_materializer_capable_node(context),
-         {:ok, {worker_ref, node}} <- create_materializer_on_node(node, recovery_attempt, context) do
-      {:ok, {:materializer, {worker_ref, node}, RecoveryAttempt.system_shard_id()}}
+         {:ok, {worker_ref, node}} <-
+           create_materializer_on_node(node, shard_tag, recovery_attempt, context) do
+      {:ok, {:materializer, {worker_ref, node}, shard_tag}}
     end
   end
 
@@ -265,18 +311,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # Create the worker via Foreman with shard_id param
-  defp create_materializer_on_node(node, recovery_attempt, context) do
+  defp create_materializer_on_node(node, shard_tag, recovery_attempt, context) do
     foreman_ref = {recovery_attempt.cluster.otp_name(:foreman), node}
     worker_id = Worker.random_id()
-    system_shard = RecoveryAttempt.system_shard_id()
 
     create_worker_fn = Map.get(context, :create_worker_fn, &Foreman.new_worker/4)
 
-    # Pass shard_id in params so materializer knows its assignment
     case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000) do
       {:ok, worker_ref} -> {:ok, {worker_ref, node}}
-      {:error, reason} -> {:error, {:failed_to_create_materializer, reason, system_shard}}
+      {:error, reason} -> {:error, {:failed_to_create_materializer, reason, shard_tag}}
     end
   end
 
@@ -307,11 +350,20 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   # Unlock materializer with only the logs it needs to start pulling
   defp unlock_and_start_pulling(materializer_pid, recovery_attempt, context) do
-    # Build TSL with only system shard logs
     system_shard = RecoveryAttempt.system_shard_id()
-    system_logs = logs_for_shard(recovery_attempt.logs, system_shard, context)
 
-    # TransactionSystemLayout is a type, not a struct, so we build a map
+    unlock_materializer_for_shard(
+      materializer_pid,
+      system_shard,
+      recovery_attempt,
+      recovery_attempt.durable_version,
+      context
+    )
+  end
+
+  defp unlock_materializer_for_shard(materializer_pid, shard_tag, recovery_attempt, durable_version, context) do
+    shard_logs = logs_for_shard(recovery_attempt.logs, shard_tag, context)
+
     tsl = %{
       id: TransactionSystemLayout.random_id(),
       epoch: recovery_attempt.epoch,
@@ -320,13 +372,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       rate_keeper: nil,
       proxies: recovery_attempt.proxies,
       resolvers: recovery_attempt.resolvers,
-      logs: system_logs,
+      logs: shard_logs,
       services: recovery_attempt.transaction_services
     }
 
     unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
 
-    case unlock_fn.(materializer_pid, recovery_attempt.durable_version, tsl) do
+    case unlock_fn.(materializer_pid, durable_version, tsl) do
       :ok -> :ok
       {:error, reason} -> {:error, {:unlock_failed, reason}}
       {:failure, reason, _ref} -> {:error, {:unlock_failed, reason}}
@@ -398,43 +450,176 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   end
 
   defp get_shard_layout(materializer_pid, read_version, context) do
+    timeout_ms = Map.get(context, :shard_layout_timeout_ms, @catchup_timeout_ms)
+    poll_interval_ms = Map.get(context, :shard_layout_poll_interval_ms, @catchup_poll_interval_ms)
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
     get_layout_fn = Map.get(context, :get_shard_layout_fn, &default_get_shard_layout/2)
-    get_layout_fn.(materializer_pid, read_version)
+
+    do_get_shard_layout(materializer_pid, read_version, get_layout_fn, deadline, poll_interval_ms)
   end
 
-  defp default_get_shard_layout(materializer_pid, read_version) do
-    # Query the materializer for shard layout via get_range on shard_keys prefix
-    prefix = Bedrock.SystemKeys.shard_keys_prefix()
-    end_key = prefix <> <<0xFF, 0xFF, 0xFF, 0xFF>>
+  defp do_get_shard_layout(materializer_pid, read_version, get_layout_fn, deadline, poll_interval_ms) do
+    if System.monotonic_time(:millisecond) > deadline do
+      {:error, :shard_layout_timeout}
+    else
+      case get_layout_fn.(materializer_pid, read_version) do
+        {:ok, shard_layout} when map_size(shard_layout) > 0 ->
+          {:ok, shard_layout}
 
-    case Materializer.get_range(materializer_pid, prefix, end_key, read_version, limit: 1000) do
-      {:ok, {entries, _more}} ->
-        shard_layout =
-          Map.new(entries, fn {key, value} ->
-            # Key format: \xff/system/shard_keys/<end_key>
-            # Value format: {tag, start_key}
-            end_key = extract_end_key_from_shard_key(key)
-            {tag, start_key} = decode_shard_value(value)
-            {end_key, {tag, start_key}}
-          end)
+        {:error, reason} when reason in [:timeout, :version_too_new] ->
+          Process.sleep(poll_interval_ms)
+          do_get_shard_layout(materializer_pid, read_version, get_layout_fn, deadline, poll_interval_ms)
 
-        {:ok, shard_layout}
+        {:error, {:shard_layout_not_found, _}} ->
+          Process.sleep(poll_interval_ms)
+          do_get_shard_layout(materializer_pid, read_version, get_layout_fn, deadline, poll_interval_ms)
 
-      {:error, reason} ->
-        {:error, {:shard_layout_query_failed, reason}}
+        {:error, reason} ->
+          {:error, reason}
 
-      {:failure, reason, _ref} ->
-        {:error, {:shard_layout_query_failed, reason}}
+        {:failure, reason, _ref} ->
+          {:error, reason}
+      end
     end
   end
 
+  defp default_get_shard_layout(materializer_pid, read_version) do
+    with {:ok, {metadata_entries, _more}} <- get_range(materializer_pid, SystemKeys.shards_prefix(), read_version),
+         {:ok, shard_layout} <- build_shard_layout_from_entries(metadata_entries) do
+      {:ok, shard_layout}
+    else
+      {:error, {:shard_layout_not_found, :empty_metadata}} ->
+        get_legacy_shard_layout(materializer_pid, read_version)
+
+      {:error, reason} ->
+        {:error, reason}
+
+      {:failure, reason, _ref} ->
+        {:error, reason}
+    end
+  end
+
+  defp get_legacy_shard_layout(materializer_pid, read_version) do
+    with {:ok, {entries, _more}} <- get_range(materializer_pid, SystemKeys.shard_keys_prefix(), read_version),
+         {:ok, shard_layout} <- build_legacy_shard_layout(entries) do
+      {:ok, shard_layout}
+    else
+      {:error, reason} -> {:error, reason}
+      {:failure, reason, _ref} -> {:error, reason}
+    end
+  end
+
+  defp get_range(materializer_pid, prefix, version) do
+    end_key = prefix <> <<0xFF, 0xFF, 0xFF, 0xFF>>
+
+    Materializer.get_range(
+      materializer_pid,
+      prefix,
+      end_key,
+      version,
+      limit: 1000,
+      timeout: @shard_layout_read_timeout_ms
+    )
+  end
+
+  defp build_shard_layout_from_entries([]), do: {:error, {:shard_layout_not_found, :empty_metadata}}
+
+  defp build_shard_layout_from_entries(entries) do
+    shard_layout =
+      Enum.reduce(entries, %{}, fn {key, value}, acc ->
+        case decode_shard_metadata_entry(key, value) do
+          {:ok, {end_key, {tag, start_key}}} ->
+            Map.put(acc, end_key, {tag, start_key})
+
+          :ignore ->
+            acc
+        end
+      end)
+
+    if map_size(shard_layout) > 0 do
+      {:ok, shard_layout}
+    else
+      {:error, {:shard_layout_not_found, :empty_metadata}}
+    end
+  end
+
+  defp decode_shard_metadata_entry(key, value) do
+    with {:shard, tag_string} <- SystemKeys.parse_key(key),
+         {tag, ""} <- Integer.parse(tag_string),
+         {:ok, metadata} <- ShardMetadata.read(value),
+         0 <- metadata.ended_at do
+      start_key = IO.iodata_to_binary(metadata.start_key)
+      end_key = IO.iodata_to_binary(metadata.end_key)
+      {:ok, {end_key, {tag, start_key}}}
+    else
+      {:ok, %{ended_at: _ended_at}} -> :ignore
+      _ -> :ignore
+    end
+  end
+
+  defp build_legacy_shard_layout([]), do: {:error, {:shard_layout_not_found, :empty_legacy_keys}}
+
+  defp build_legacy_shard_layout(entries) do
+    shard_layout =
+      entries
+      |> Enum.sort_by(fn {key, _value} -> extract_end_key_from_shard_key(key) end)
+      |> Enum.reduce({%{}, <<>>}, fn {key, value}, {acc, start_key} ->
+        end_key = extract_end_key_from_shard_key(key)
+
+        next_entry =
+          case decode_legacy_shard_value(value, start_key) do
+            {:ok, {tag, resolved_start_key}} ->
+              {Map.put(acc, end_key, {tag, resolved_start_key}), end_key}
+
+            :ignore ->
+              {acc, start_key}
+          end
+
+        next_entry
+      end)
+      |> elem(0)
+
+    if map_size(shard_layout) > 0 do
+      {:ok, shard_layout}
+    else
+      {:error, {:shard_layout_not_found, :empty_legacy_keys}}
+    end
+  end
+
+  defp resolver_descriptors_for_shard_layout(shard_layout) when is_map(shard_layout) do
+    shard_layout
+    |> Map.values()
+    |> Enum.map(fn {_tag, start_key} -> start_key end)
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.with_index(1)
+    |> Enum.map(fn {start_key, index} -> resolver_descriptor(start_key, {:vacancy, index}) end)
+  end
+
   defp extract_end_key_from_shard_key(key) do
-    prefix = Bedrock.SystemKeys.shard_keys_prefix()
+    prefix = SystemKeys.shard_keys_prefix()
     prefix_len = byte_size(prefix)
     binary_part(key, prefix_len, byte_size(key) - prefix_len)
   end
 
-  defp decode_shard_value(value) when is_binary(value) do
-    :erlang.binary_to_term(value)
+  defp decode_legacy_shard_value(value, inferred_start_key) when is_binary(value) do
+    case :erlang.binary_to_term(value) do
+      {tag, start_key} when is_integer(tag) and is_binary(start_key) ->
+        {:ok, {tag, start_key}}
+
+      tag when is_integer(tag) ->
+        {:ok, {tag, inferred_start_key}}
+
+      _ ->
+        :ignore
+    end
+  end
+
+  defp shard_label(shard_tag) do
+    if shard_tag == RecoveryAttempt.system_shard_id() do
+      "System shard"
+    else
+      "Shard #{shard_tag}"
+    end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
@@ -107,17 +107,45 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
       assert {:log, 2} in result.survivor_log_ids
     end
 
-    test "shard_tags in old_logs are ignored (consistent hashing)" do
-      # Old logs may have shard_tags from previous layout, but they are ignored
+    test "rebuilds consistent-hash recovery layout from fresh log vacancies" do
+      log_recovery_info = %{{:log, 1} => log_info(10, 50), {:log, 3} => log_info(5, 45)}
+
+      old_logs = %{
+        {:log, 1} => [],
+        {:log, 2} => [],
+        {:log, 3} => []
+      }
+
+      {recovery_attempt, context} = recovery_setup(log_recovery_info, old_logs, 3)
+
+      assert {%{logs: logs}, LogRecruitmentPhase} =
+               LogRecoveryPlanningPhase.execute(recovery_attempt, context)
+
+      assert logs == %{{:vacancy, 1} => [], {:vacancy, 2} => [], {:vacancy, 3} => []}
+    end
+
+    test "uses fresh vacancies for all-empty consistent-hash layouts" do
+      log_recovery_info = %{{:log, 1} => log_info(10, 50), {:log, 2} => log_info(5, 45)}
+      old_logs = %{{:log, 1} => [], {:log, 2} => []}
+      {recovery_attempt, context} = recovery_setup(log_recovery_info, old_logs, 2)
+
+      assert {%{logs: logs, old_log_ids_to_copy: old_log_ids}, LogRecruitmentPhase} =
+               LogRecoveryPlanningPhase.execute(recovery_attempt, context)
+
+      assert length(old_log_ids) == 2
+      assert logs == %{{:vacancy, 1} => [], {:vacancy, 2} => []}
+    end
+
+    test "preserves survivor descriptors for legacy non-empty layouts" do
       log_recovery_info = %{{:log, 1} => log_info(10, 50), {:log, 2} => log_info(5, 45)}
       old_logs = %{{:log, 1} => ["tag_a", "tag_b"], {:log, 2} => ["tag_a"]}
       {recovery_attempt, context} = recovery_setup(log_recovery_info, old_logs, 2)
 
-      # Should still succeed - shard_tags are ignored
-      assert {%{old_log_ids_to_copy: old_log_ids}, LogRecruitmentPhase} =
+      assert {%{logs: logs, old_log_ids_to_copy: old_log_ids}, LogRecruitmentPhase} =
                LogRecoveryPlanningPhase.execute(recovery_attempt, context)
 
       assert length(old_log_ids) == 2
+      assert logs == old_logs
     end
   end
 

--- a/test/bedrock/control_plane/director/recovery/log_replay_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_replay_phase_test.exs
@@ -44,6 +44,59 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhaseTest do
       assert result == :ok
     end
 
+    test "skips replay for retained survivor logs" do
+      test_pid = self()
+      survivor_log_ids = ["survivor"]
+      new_log_ids = ["survivor"]
+      version_vector = {Version.from_integer(0), Version.from_integer(10)}
+
+      recovery_attempt = %{service_pids: %{"survivor" => self()}}
+
+      copy_log_data_fn = fn _new_log_id, _survivor_pids, _first_version, _last_version, _service_pids ->
+        send(test_pid, :copy_called)
+        {:ok, self()}
+      end
+
+      assert :ok =
+               LogReplayPhase.replay_into_new_logs(
+                 survivor_log_ids,
+                 new_log_ids,
+                 version_vector,
+                 recovery_attempt,
+                 %{copy_log_data_fn: copy_log_data_fn}
+               )
+
+      refute_received :copy_called
+    end
+
+    test "replays only newly recruited logs when survivors are retained" do
+      test_pid = self()
+      survivor_pid = spawn(fn -> :ok end)
+      new_log_pid = spawn(fn -> :ok end)
+      survivor_log_ids = ["survivor"]
+      new_log_ids = ["survivor", "new-log"]
+      version_vector = {Version.from_integer(0), Version.from_integer(10)}
+
+      recovery_attempt = %{service_pids: %{"survivor" => survivor_pid, "new-log" => new_log_pid}}
+
+      copy_log_data_fn = fn new_log_id, survivor_pids, _first_version, _last_version, _service_pids ->
+        send(test_pid, {:copy_called, new_log_id, survivor_pids})
+        {:ok, new_log_pid}
+      end
+
+      assert :ok =
+               LogReplayPhase.replay_into_new_logs(
+                 survivor_log_ids,
+                 new_log_ids,
+                 version_vector,
+                 recovery_attempt,
+                 %{copy_log_data_fn: copy_log_data_fn}
+               )
+
+      assert_received {:copy_called, "new-log", [^survivor_pid]}
+      refute_received {:copy_called, "survivor", _}
+    end
+
     # Note: Tests that call Log.recover_from are commented out since
     # they require proper log process mocking which is complex in unit tests
     # The function's core logic is tested through the pair_with_old_log_ids tests

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -9,6 +9,27 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
   alias Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase
   alias Bedrock.DataPlane.Version
   alias Bedrock.Internal.LayoutRouting
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.ShardMetadata
+
+  defmodule FakeRangeMaterializer do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+
+    @impl true
+    def handle_call({:get_range, start_key, end_key, version, opts}, _from, state) do
+      send(state[:test_pid], {:get_range, start_key, end_key, version, opts})
+      reply = state[:range_reply_fn].(start_key, end_key, version, opts)
+      {:reply, reply, state}
+    end
+  end
 
   describe "execute/2" do
     test "for fresh cluster, creates default shard layout and materializers" do
@@ -110,6 +131,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "uses existing materializer from available_services (legacy format)" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       recovery_attempt =
@@ -128,11 +150,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "metadata_materializer" => {:materializer, {:test_materializer, node()}}
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
@@ -146,6 +173,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
           assert updated_attempt.metadata_materializer == materializer_pid
           assert updated_attempt.shard_layout
+          assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
+
+          assert updated_attempt.resolvers == [
+                   %{start_key: <<>>, resolver: {:vacancy, 1}},
+                   %{start_key: <<0xFF>>, resolver: {:vacancy, 2}}
+                 ]
         end)
 
       assert log =~ "Materializer caught up to version"
@@ -153,6 +186,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "uses materializer from available_services (shard-based format)" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       recovery_attempt =
@@ -171,11 +205,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "mat_sys_0" => {:materializer, {:test_materializer, node()}, 0}
+          "mat_sys_0" => {:materializer, {:test_materializer, node()}, 0},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}, 0}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
@@ -189,6 +228,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
           assert updated_attempt.metadata_materializer == materializer_pid
           assert updated_attempt.shard_layout
+          assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
+
+          assert updated_attempt.resolvers == [
+                   %{start_key: <<>>, resolver: {:vacancy, 1}},
+                   %{start_key: <<0xFF>>, resolver: {:vacancy, 2}}
+                 ]
         end)
 
       assert log =~ "Materializer caught up to version"
@@ -353,6 +398,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "filters logs to only system shard when unlocking" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       # Logs with different shard assignments
@@ -369,7 +415,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> Map.put(:logs, logs)
         |> Map.put(:durable_version, durable_version)
 
-      received_tsl = :ets.new(:test_tsl, [:set, :public])
+      received_tsl = :ets.new(:test_tsl, [:bag, :public])
 
       context =
         [
@@ -379,14 +425,19 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "metadata_materializer" => {:materializer, {:test_materializer, node()}}
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
-        |> Map.put(:unlock_materializer_fn, fn _pid, _version, tsl ->
-          :ets.insert(received_tsl, {:tsl, tsl})
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
+          :ets.insert(received_tsl, {pid, tsl})
           :ok
         end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
@@ -398,10 +449,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {_updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          # Verify that only system shard logs were passed to unlock
-          [{:tsl, tsl}] = :ets.lookup(received_tsl, :tsl)
-          assert Map.keys(tsl.logs) == ["log_1"]
-          refute Map.has_key?(tsl.logs, "log_2")
+          [{^materializer_pid, system_tsl}] = :ets.lookup(received_tsl, materializer_pid)
+          [{^user_materializer_pid, user_tsl}] = :ets.lookup(received_tsl, user_materializer_pid)
+
+          assert Map.keys(system_tsl.logs) == ["log_1"]
+          refute Map.has_key?(system_tsl.logs, "log_2")
+          assert Map.keys(user_tsl.logs) == ["log_2"]
+          refute Map.has_key?(user_tsl.logs, "log_1")
         end)
 
       assert log =~ "Materializer caught up to version"
@@ -411,6 +465,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "uses consistent-hash log selection when descriptors are empty" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       logs = %{
@@ -426,7 +481,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> Map.put(:logs, logs)
         |> Map.put(:durable_version, durable_version)
 
-      received_tsl = :ets.new(:consistent_hash_tsl, [:set, :public])
+      received_tsl = :ets.new(:consistent_hash_tsl, [:bag, :public])
 
       context =
         [
@@ -436,14 +491,19 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "metadata_materializer" => {:materializer, {:test_materializer, node()}}
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
-        |> Map.put(:unlock_materializer_fn, fn _pid, _version, tsl ->
-          :ets.insert(received_tsl, {:tsl, tsl})
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
+          :ets.insert(received_tsl, {pid, tsl})
           :ok
         end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.update!(:cluster_config, &merge_parameters(&1, %{desired_replication_factor: 1}))
@@ -454,14 +514,149 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {_updated_attempt, CommitProxyStartupPhase} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-      [{:tsl, tsl}] = :ets.lookup(received_tsl, :tsl)
+      [{^materializer_pid, system_tsl}] = :ets.lookup(received_tsl, materializer_pid)
+      [{^user_materializer_pid, user_tsl}] = :ets.lookup(received_tsl, user_materializer_pid)
 
-      expected_log_ids = LayoutRouting.log_ids_for_shard(logs, 0, 1)
-
-      assert Map.keys(tsl.logs) == expected_log_ids
-      refute tsl.logs == %{}
+      assert Map.keys(system_tsl.logs) == LayoutRouting.log_ids_for_shard(logs, 0, 1)
+      assert Map.keys(user_tsl.logs) == LayoutRouting.log_ids_for_shard(logs, 1, 1)
+      refute system_tsl.logs == %{}
+      refute user_tsl.logs == %{}
 
       :ets.delete(received_tsl)
+    end
+
+    test "reads shard layout from shard metadata at the recovered read version" do
+      durable_version = Version.from_integer(100)
+      newer_version = Version.from_integer(200)
+      shards_prefix = SystemKeys.shards_prefix()
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      {:ok, materializer_pid} =
+        FakeRangeMaterializer.start_link(
+          test_pid: self(),
+          range_reply_fn: fn _start_key, _end_key, _version, _opts ->
+            {:ok,
+             {[
+                {SystemKeys.shard(0), ShardMetadata.new(<<0xFF>>, Bedrock.end_of_keyspace(), 0)},
+                {SystemKeys.shard(1), ShardMetadata.new(<<>>, <<0xFF>>, 0)}
+              ], false}}
+          end
+        )
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:metadata_materializer, nil)
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, %{"log_1" => [0, 1]})
+        |> Map.put(:durable_version, durable_version)
+        |> Map.put(:version_vector, {Version.zero(), newer_version})
+
+      context =
+        [
+          old_transaction_system_layout: %{
+            logs: %{"log_1" => [0, 1]}
+          }
+        ]
+        |> create_test_context()
+        |> Map.put(:available_services, %{
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
+        })
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
+          {:ok, %{durable_version: durable_version}}
+        end)
+
+      assert {updated_attempt, CommitProxyStartupPhase} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+      assert updated_attempt.shard_layout == %{
+               Bedrock.end_of_keyspace() => {0, <<0xFF>>},
+               <<0xFF>> => {1, <<>>}
+             }
+
+      assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
+
+      assert_received {:get_range, start_key, end_key, ^newer_version, opts}
+      assert start_key == shards_prefix
+      assert end_key == shards_prefix <> <<0xFF, 0xFF, 0xFF, 0xFF>>
+      assert opts[:timeout] == 5_000
+      assert opts[:limit] == 1000
+    end
+
+    test "falls back to legacy shard keys when shard metadata is absent" do
+      durable_version = Version.from_integer(100)
+      read_version = Version.from_integer(150)
+      shards_prefix = SystemKeys.shards_prefix()
+      shard_keys_prefix = SystemKeys.shard_keys_prefix()
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      {:ok, materializer_pid} =
+        FakeRangeMaterializer.start_link(
+          test_pid: self(),
+          range_reply_fn: fn start_key, _end_key, _version, _opts ->
+            case start_key do
+              ^shards_prefix ->
+                {:ok, {[], false}}
+
+              ^shard_keys_prefix ->
+                {:ok,
+                 {[
+                    {SystemKeys.shard_key(<<0xFF>>), :erlang.term_to_binary(1)},
+                    {SystemKeys.shard_key(Bedrock.end_of_keyspace()), :erlang.term_to_binary(0)}
+                  ], false}}
+            end
+          end
+        )
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:metadata_materializer, nil)
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, %{"log_1" => [0, 1]})
+        |> Map.put(:durable_version, durable_version)
+        |> Map.put(:version_vector, {Version.zero(), read_version})
+
+      context =
+        [
+          old_transaction_system_layout: %{
+            logs: %{"log_1" => [0, 1]}
+          }
+        ]
+        |> create_test_context()
+        |> Map.put(:available_services, %{
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:test_user_materializer, node()}, 1}
+        })
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:test_user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
+          {:ok, %{durable_version: durable_version}}
+        end)
+
+      assert {updated_attempt, CommitProxyStartupPhase} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+      assert updated_attempt.shard_layout == %{
+               Bedrock.end_of_keyspace() => {0, <<0xFF>>},
+               <<0xFF>> => {1, <<>>}
+             }
+
+      assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
+
+      assert_received {:get_range, start_key, _, ^read_version, _}
+      assert start_key == shards_prefix
+      assert_received {:get_range, legacy_start_key, _, ^read_version, _}
+      assert legacy_start_key == shard_keys_prefix
     end
   end
 

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -235,16 +235,15 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
     test "existing cluster stalls when sequencer fails to start" do
       recovery_attempt = create_existing_cluster_recovery_attempt()
+      old_layout = %{logs: %{"existing_log_1" => [0, 100]}}
+      services = %{"existing_log_1" => {:log, {:log_worker_existing_1, :node1}}}
 
       context =
-        create_test_context(
-          old_transaction_system_layout: %{
-            logs: %{"existing_log_1" => [0, 100]}
-          }
-        )
+        services
+        |> create_coordinator_format_context(old_transaction_system_layout: old_layout)
+        |> Map.put(:start_supervised_fn, fn _child_spec, _node -> {:error, :test_start_error} end)
 
-      # Without full mocking, recovery fails at sequencer start.
-      assert {{:error, {:failed_to_start, :sequencer, _, _}}, _stalled_attempt} =
+      assert {{:error, {:failed_to_start, :sequencer, _, :test_start_error}}, _stalled_attempt} =
                Recovery.run_recovery_attempt(recovery_attempt, context)
     end
 
@@ -332,8 +331,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
                Recovery.run_recovery_attempt(recovery_attempt, context)
     end
 
-    test "recovery with coordinator-format services handles existing cluster (regression test)" do
-      # Validates coordinator services work with existing cluster recovery
+    test "recovery with coordinator-format services completes existing cluster recovery" do
       old_layout = %{
         logs: %{"existing_log_1" => [0, 100]}
       }
@@ -349,41 +347,46 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       # Include materializer so MaterializerBootstrapPhase passes
       materializer_pid = spawn(fn -> Process.sleep(5000) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(5000) end)
 
       coordinator_services = %{
         "existing_log_1" => {:log, {:log_worker_existing_1, :node1}},
-        "storage_1" => {:materializer, {:storage_worker_1, :node1}},
         "metadata_materializer" => {:materializer, {:materializer, :node1}}
       }
 
       context =
         coordinator_services
         |> create_coordinator_format_context(old_transaction_system_layout: old_layout)
-        |> Map.update!(
-          :available_services,
-          &Map.put(&1, "metadata_materializer", {:materializer, {:materializer, :node1}})
-        )
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:node_capabilities, %{
+          log: [:node1@host, :node2@host, :node3@host],
+          storage: [:node1@host, :node2@host, :node3@host],
+          materializer: [:node1@host, :node2@host, :node3@host],
+          coordination: [:node1@host, :node2@host, :node3@host],
+          resolution: [:node1@host, :node2@host, :node3@host]
+        })
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {_worker_ref, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+        |> Map.put(:materializer_info_fn, fn pid, [:durable_version]
+                                             when pid in [materializer_pid, user_materializer_pid] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
         end)
 
-      # Stalls at TopologyPhase validation due to no resolvers.
       log =
         capture_log(fn ->
-          assert {{:stalled, {:recovery_system_failed, {:invalid_recovery_state, :no_resolvers}}}, stalled_attempt} =
-                   Recovery.run_recovery_attempt(recovery_attempt, context)
+          assert {:ok, completed_attempt} = Recovery.run_recovery_attempt(recovery_attempt, context)
 
-          # Verify service tracking was populated during recovery
-          assert Map.has_key?(stalled_attempt.service_pids, "existing_log_1")
-          assert Map.has_key?(stalled_attempt.transaction_services, "existing_log_1")
+          assert Map.has_key?(completed_attempt.service_pids, "existing_log_1")
+          assert Map.has_key?(completed_attempt.transaction_services, "existing_log_1")
+          assert completed_attempt.metadata_materializer == materializer_pid
+          assert completed_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
         end)
 
-      # Materializer bootstrap phase should log catchup completion
       assert log =~ "Materializer caught up to version"
     end
 
@@ -618,8 +621,11 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
   end
 
   defp with_mocked_transactions(context) do
-    commit_transaction_fn = fn _proxy, _transaction -> {:ok, 101} end
-    unlock_commit_proxy_fn = fn _proxy, _lock_token, _layout -> :ok end
+    commit_transaction_fn = fn _proxy, _epoch, _transaction ->
+      {:ok, Version.from_integer(101), Version.from_integer(1)}
+    end
+
+    unlock_commit_proxy_fn = fn _proxy, _lock_token, _sequencer, _resolver_layout, _routing_data -> :ok end
     unlock_storage_fn = fn _storage_pid, _durable_version, _layout -> :ok end
 
     context

--- a/test/bedrock/repo_durability_test.exs
+++ b/test/bedrock/repo_durability_test.exs
@@ -88,6 +88,7 @@ defmodule Bedrock.RepoDurabilityTest do
 
   defp ensure_local_node_started! do
     if Node.self() == :nonode@nohost do
+      ensure_epmd_started!()
       node_name = :"bedrock_repo_durability_#{System.unique_integer([:positive])}"
 
       case :net_kernel.start([node_name, :shortnames]) do
@@ -103,6 +104,20 @@ defmodule Bedrock.RepoDurabilityTest do
       end
     else
       :ok
+    end
+  end
+
+  defp ensure_epmd_started! do
+    epmd =
+      System.find_executable("epmd") ||
+        flunk("failed to locate epmd executable required for distributed durability test")
+
+    case System.cmd(epmd, ["-daemon"], stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {output, status} ->
+        flunk("failed to start epmd for distributed durability test: status=#{status} output=#{inspect(output)}")
     end
   end
 

--- a/test/bedrock/repo_durability_test.exs
+++ b/test/bedrock/repo_durability_test.exs
@@ -1,0 +1,367 @@
+defmodule Bedrock.RepoDurabilityTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Repo
+
+  defmodule TestCluster do
+    @moduledoc false
+    use Bedrock.Cluster, otp_app: :bedrock, name: "repo_durability_test_cluster"
+  end
+
+  defmodule TestRepo do
+    @moduledoc false
+    use Repo, cluster: TestCluster
+  end
+
+  @tag :tmp_dir
+  test "fresh single-node clusters can read committed data before and after restart", %{tmp_dir: tmp_dir} do
+    ensure_local_node_started!()
+
+    config = node_config(tmp_dir)
+    original_config = Application.get_env(:bedrock, TestCluster)
+    Application.put_env(:bedrock, TestCluster, config)
+
+    on_exit(fn ->
+      if is_nil(original_config) do
+        Application.delete_env(:bedrock, TestCluster)
+      else
+        Application.put_env(:bedrock, TestCluster, original_config)
+      end
+    end)
+
+    supervisor = start_cluster_supervisor()
+    wait_for_layout!()
+
+    assert :ok =
+             TestRepo.transact(
+               fn ->
+                 TestRepo.put("k1", "v1")
+               end,
+               retry_limit: 5
+             )
+
+    assert {:ok, "v1"} =
+             TestRepo.transact(
+               fn ->
+                 {:ok, TestRepo.get("k1")}
+               end,
+               retry_limit: 5
+             )
+
+    wait_for_bootstrap!(tmp_dir)
+    stop_cluster_supervisor!(supervisor)
+
+    restarted_supervisor = start_cluster_supervisor()
+    wait_for_layout!()
+
+    assert {:ok, "v1"} =
+             TestRepo.transact(
+               fn ->
+                 {:ok, TestRepo.get("k1")}
+               end,
+               retry_limit: 5
+             )
+
+    stop_cluster_supervisor!(restarted_supervisor)
+  end
+
+  defp node_config(tmp_dir) do
+    object_storage =
+      ObjectStorage.backend(
+        LocalFilesystem,
+        root: Path.join([tmp_dir, "coordinator", "object_storage"])
+      )
+
+    [
+      capabilities: [:coordination, :log, :materializer],
+      path_to_descriptor: Path.join(tmp_dir, "bedrock.cluster"),
+      object_storage: object_storage,
+      trace: [:recovery, :storage],
+      coordinator: [path: Path.join(tmp_dir, "coordinator"), persistent: true],
+      worker: [path: Path.join(tmp_dir, "workers")],
+      durability_mode: :relaxed,
+      durability: [desired_replication_factor: 1, desired_logs: 1]
+    ]
+  end
+
+  defp ensure_local_node_started! do
+    if Node.self() == :nonode@nohost do
+      node_name = :"bedrock_repo_durability_#{System.unique_integer([:positive])}"
+
+      case :net_kernel.start([node_name, :shortnames]) do
+        {:ok, _pid} ->
+          Node.set_cookie(:bedrock_repo_durability)
+          :ok
+
+        {:error, {:already_started, _pid}} ->
+          :ok
+
+        {:error, reason} ->
+          flunk("failed to start local Erlang node: #{inspect(reason)}")
+      end
+    else
+      :ok
+    end
+  end
+
+  defp start_cluster_supervisor do
+    {:ok, supervisor} = Supervisor.start_link([TestCluster.child_spec([])], strategy: :one_for_one)
+    supervisor
+  end
+
+  defp stop_cluster_supervisor!(supervisor) do
+    Supervisor.stop(supervisor, :normal, 30_000)
+
+    assert_eventually(fn ->
+      is_nil(Process.whereis(TestCluster.otp_name(:link))) and
+        is_nil(Process.whereis(TestCluster.otp_name(:coordinator))) and
+        is_nil(Process.whereis(TestCluster.otp_name(:foreman)))
+    end)
+  end
+
+  defp wait_for_layout!(timeout_ms \\ 20_000) do
+    Process.put(:last_layout_result, nil)
+    Process.put(:last_director_down_reason, nil)
+    Process.put(:director_monitor, nil)
+
+    assert_eventually(
+      fn ->
+        track_director_failure()
+        result = TestCluster.fetch_transaction_system_layout()
+        Process.put(:last_layout_result, result)
+        layout_ready?(result, current_coordinator_state())
+      end,
+      timeout_ms,
+      &layout_wait_failure_message/0
+    )
+  end
+
+  defp layout_ready?(
+         {:ok,
+          %{
+            epoch: layout_epoch,
+            logs: logs,
+            services: services,
+            proxies: proxies,
+            resolvers: resolvers,
+            shard_layout: shard_layout,
+            metadata_materializer: metadata_materializer,
+            shard_materializers: shard_materializers
+          }},
+         %{epoch: coordinator_epoch}
+       ) do
+    layout_epoch == coordinator_epoch and
+      populated?(logs) and
+      populated?(services) and
+      populated_list?(proxies) and
+      populated_list?(resolvers) and
+      populated?(shard_layout) and
+      is_pid(metadata_materializer) and
+      populated?(shard_materializers) and
+      shard_materializers_cover_layout?(shard_layout, shard_materializers)
+  end
+
+  defp layout_ready?(_, _), do: false
+
+  defp populated?(value) when is_map(value), do: map_size(value) > 0
+  defp populated?(_value), do: false
+
+  defp populated_list?(value) when is_list(value), do: value != []
+  defp populated_list?(_value), do: false
+
+  defp layout_wait_failure_message do
+    "last layout result: #{inspect(Process.get(:last_layout_result), limit: :infinity)}\n" <>
+      "director state: #{inspect(current_director_state(), limit: :infinity)}\n" <>
+      "director process info: #{inspect(current_director_process_info(), limit: :infinity)}\n" <>
+      "coordinator state: #{inspect(current_coordinator_state(), limit: :infinity)}\n" <>
+      "log states: #{inspect(current_log_states(), limit: :infinity)}\n" <>
+      "materializer states: #{inspect(current_materializer_states(), limit: :infinity)}\n" <>
+      "last director down reason: #{inspect(Process.get(:last_director_down_reason), limit: :infinity)}"
+  end
+
+  defp track_director_failure do
+    drain_director_down_messages()
+
+    case {Process.get(:director_monitor), current_director_pid()} do
+      {nil, pid} when is_pid(pid) ->
+        Process.put(:director_monitor, Process.monitor(pid))
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp drain_director_down_messages do
+    receive do
+      {:DOWN, monitor_ref, :process, _pid, reason} ->
+        if Process.get(:director_monitor) == monitor_ref do
+          Process.put(:director_monitor, nil)
+          Process.put(:last_director_down_reason, reason)
+        end
+
+        drain_director_down_messages()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp shard_materializers_cover_layout?(shard_layout, shard_materializers) do
+    shard_layout
+    |> Map.values()
+    |> Enum.map(fn {tag, _start_key} -> tag end)
+    |> Enum.uniq()
+    |> Enum.all?(&match?(pid when is_pid(pid), Map.get(shard_materializers, &1)))
+  end
+
+  defp current_director_pid do
+    case Process.whereis(TestCluster.otp_name(:coordinator)) do
+      nil ->
+        nil
+
+      coordinator_pid ->
+        case :sys.get_state(coordinator_pid) do
+          %{director: director_pid} when is_pid(director_pid) -> director_pid
+          _ -> nil
+        end
+    end
+  end
+
+  defp current_director_state do
+    case current_director_pid() do
+      pid when is_pid(pid) ->
+        try do
+          :sys.get_state(pid, 1_000)
+        catch
+          :exit, reason -> {:director_state_unavailable, reason}
+        end
+
+      _ ->
+        :director_unavailable
+    end
+  end
+
+  defp current_director_process_info do
+    case current_director_pid() do
+      pid when is_pid(pid) ->
+        Process.info(pid, [:status, :current_function, :current_stacktrace, :message_queue_len, :messages])
+
+      _ ->
+        :director_unavailable
+    end
+  end
+
+  defp current_coordinator_state do
+    case Process.whereis(TestCluster.otp_name(:coordinator)) do
+      pid when is_pid(pid) ->
+        try do
+          :sys.get_state(pid, 1_000)
+        catch
+          :exit, reason -> {:coordinator_state_unavailable, reason}
+        end
+
+      _ ->
+        :coordinator_unavailable
+    end
+  end
+
+  defp current_materializer_states do
+    case current_coordinator_state() do
+      %{service_directory: service_directory} when is_map(service_directory) ->
+        service_directory
+        |> Enum.filter(fn {_service_id, {kind, _location}} -> kind == :materializer end)
+        |> Enum.map(fn {service_id, {_kind, {otp_name, _node}}} ->
+          pid = Process.whereis(otp_name)
+
+          {service_id,
+           %{
+             pid: pid,
+             alive?: is_pid(pid) and Process.alive?(pid),
+             process_info:
+               if(is_pid(pid),
+                 do: Process.info(pid, [:status, :current_function, :message_queue_len]),
+                 else: :unavailable
+               ),
+             pull_task_info:
+               case safe_sys_get_state(pid) do
+                 %{pull_task: %Task{pid: task_pid}} when is_pid(task_pid) ->
+                   Process.info(task_pid, [:status, :current_function, :current_stacktrace, :message_queue_len])
+
+                 _ ->
+                   :unavailable
+               end,
+             state: if(is_pid(pid), do: safe_sys_get_state(pid), else: :unavailable)
+           }}
+        end)
+
+      _ ->
+        :coordinator_unavailable
+    end
+  end
+
+  defp current_log_states do
+    case current_coordinator_state() do
+      %{service_directory: service_directory} when is_map(service_directory) ->
+        service_directory
+        |> Enum.filter(fn {_service_id, {kind, _location}} -> kind == :log end)
+        |> Enum.map(fn {service_id, {_kind, {otp_name, _node}}} ->
+          pid = Process.whereis(otp_name)
+
+          {service_id,
+           %{
+             pid: pid,
+             alive?: is_pid(pid) and Process.alive?(pid),
+             process_info:
+               if(is_pid(pid),
+                 do: Process.info(pid, [:status, :current_function, :message_queue_len]),
+                 else: :unavailable
+               ),
+             state: if(is_pid(pid), do: safe_sys_get_state(pid), else: :unavailable)
+           }}
+        end)
+
+      _ ->
+        :coordinator_unavailable
+    end
+  end
+
+  defp safe_sys_get_state(pid) do
+    :sys.get_state(pid, 1_000)
+  catch
+    :exit, reason -> {:sys_state_unavailable, reason}
+  end
+
+  defp wait_for_bootstrap!(tmp_dir, timeout_ms \\ 10_000) do
+    backend =
+      ObjectStorage.backend(
+        LocalFilesystem,
+        root: Path.join([tmp_dir, "coordinator", "object_storage"])
+      )
+
+    assert_eventually(
+      fn ->
+        match?({:ok, _data}, ObjectStorage.get(backend, "bootstrap"))
+      end,
+      timeout_ms
+    )
+  end
+
+  defp assert_eventually(fun, timeout_ms \\ 5_000, failure_message_fun \\ fn -> "condition not met before timeout" end) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_assert_eventually(fun, deadline, failure_message_fun)
+  end
+
+  defp do_assert_eventually(fun, deadline, failure_message_fun) do
+    if fun.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        flunk(failure_message_fun.())
+      else
+        Process.sleep(100)
+        do_assert_eventually(fun, deadline, failure_message_fun)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- restore persisted single-node restart recovery
- carry survivor log descriptors into the recovery attempt
- skip replay for retained survivor logs and reconstruct shard layout from recovered shard metadata
- add a persisted restart regression test

## Notes
- Depends on #72. This branch was developed on top of the fresh-cluster routing fix because persisted restart still relies on the consistent-hash recovery path introduced there.
- This PR does not include the waitlist timeout fix from #73.

## Verification
- mix test test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs test/bedrock/control_plane/director/recovery/log_replay_phase_test.exs test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
- mix test test/bedrock/control_plane/director/recovery_test.exs
- mix test test/bedrock/repo_durability_test.exs

Closes #71