### PR TITLE
fix materializer recovery for empty log descriptors

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -282,11 +282,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # Filter logs to only those relevant for the given shard (by tag)
   defp filter_logs_for_shard(logs, shard_id) do
     logs
-    |> Enum.filter(fn {_log_id, tags} ->
-      shard_id in tags
-    end)
+    |> Enum.filter(fn {_log_id, tags} -> log_routes_to_shard?(tags, shard_id) end)
     |> Map.new()
   end
+
+  defp log_routes_to_shard?([], _shard_id), do: true
+  defp log_routes_to_shard?(tags, shard_id), do: shard_id in tags
 
   # Unlock materializer with only the logs it needs to start pulling
   defp unlock_and_start_pulling(materializer_pid, recovery_attempt, context) do

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -75,6 +75,55 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       :ets.delete(created_shards)
     end
 
+    test "for fresh cluster, unlocks shard materializers with empty log descriptors" do
+      system_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      logs = %{
+        {:vacancy, 1} => [],
+        {:vacancy, 2} => []
+      }
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:metadata_materializer, nil)
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, logs)
+
+      unlocks = :ets.new(:materializer_unlocks, [:bag, :public])
+
+      context =
+        [
+          old_transaction_system_layout: %{logs: %{}},
+          node_capabilities: %{
+            log: [Node.self()],
+            materializer: [Node.self()]
+          }
+        ]
+        |> create_test_context()
+        |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
+          {:ok, :new_materializer_ref}
+        end)
+        |> Map.put(:lock_materializer_fn, fn {:materializer, _ref, shard_tag}, _epoch ->
+          pid = if shard_tag == 0, do: system_materializer_pid, else: user_materializer_pid
+          {:ok, pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
+          :ets.insert(unlocks, {:unlock, pid, tsl.logs})
+          :ok
+        end)
+
+      assert {updated_attempt, CommitProxyStartupPhase} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+      assert updated_attempt.metadata_materializer == system_materializer_pid
+
+      assert {:unlock, system_materializer_pid, logs} in :ets.lookup(unlocks, :unlock)
+      assert {:unlock, user_materializer_pid, logs} in :ets.lookup(unlocks, :unlock)
+
+      :ets.delete(unlocks)
+    end
+
     test "stalls when no materializer capable nodes exist" do
       recovery_attempt =
         recovery_attempt()


### PR DESCRIPTION
## Summary

- Treat empty log descriptors as runtime-routed logs when recovery unlocks shard materializers.
- Keep legacy tag-filtered descriptors scoped to the matching shard.
- Add a fresh-cluster regression for Bedrock 0.5-style empty log descriptors.

## Root Cause

Fresh Bedrock 0.5 layouts use empty log descriptors because shard-to-log routing is computed at runtime. Recovery still filtered materializer unlock logs by shard tag, so `[]` matched no shard and each fresh-cluster materializer started with no logs to pull from.

```mermaid
flowchart LR
    A[Recovery logs] --> B{Descriptor}
    B -->|empty list| C[Runtime routed log]
    B -->|tag list| D[Shard tag filter]
    C --> E[Materializer unlock logs]
    D --> E
    E --> F[Pull committed transactions]
```

Refs bedrock-kv/job_queue#6.
