### PR TITLE
[codex] Recover shard materializers on restart

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -54,10 +54,12 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
     :service_pids,
     :transaction_system_layout,
     :metadata_materializer,
-    :shard_layout
+    :shard_layout,
+    shard_materializers: %{}
   ]
 
   @type shard_layout :: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}}
+  @type shard_materializers :: %{Bedrock.range_tag() => pid()}
 
   @type t :: %__MODULE__{
           attempt: non_neg_integer(),
@@ -79,7 +81,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           metadata_materializer: pid() | nil,
-          shard_layout: shard_layout() | nil
+          shard_layout: shard_layout() | nil,
+          shard_materializers: shard_materializers()
         }
 
   @doc """
@@ -116,7 +119,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       service_pids: %{},
       transaction_system_layout: nil,
       metadata_materializer: nil,
-      shard_layout: nil
+      shard_layout: nil,
+      shard_materializers: %{}
     }
   end
 end

--- a/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
@@ -31,7 +31,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
 
   @impl true
   def execute(%RecoveryAttempt{} = recovery_attempt, context) do
-    old_log_ids = Map.keys(context.old_transaction_system_layout[:logs] || %{})
+    old_logs = context.old_transaction_system_layout[:logs] || %{}
+    old_log_ids = Map.keys(old_logs)
     log_recovery_info = recovery_attempt.log_recovery_info_by_id
     locked_count = map_size(log_recovery_info)
     total_count = length(old_log_ids)
@@ -49,6 +50,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
             recovery_attempt
             |> Map.put(:old_log_ids_to_copy, survivor_ids)
             |> Map.put(:survivor_log_ids, survivor_ids)
+            |> Map.put(:logs, Map.take(old_logs, survivor_ids))
             |> Map.put(:version_vector, version_vector)
             |> Map.put(:durable_version, durable_version)
 

--- a/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
@@ -89,7 +89,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase do
 
   defp get_available_log_ids(%{available_services: available_services}) do
     available_services
-    |> Enum.filter(fn {_id, {kind, _}} -> kind == :log end)
+    |> Enum.filter(fn
+      {_id, {:log, _ref}} -> true
+      _service -> false
+    end)
     |> MapSet.new(&elem(&1, 0))
   end
 

--- a/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
@@ -153,13 +153,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
           service_pids :: %{Log.id() => pid()}
         ) :: {:ok, pid()} | {:error, term()}
   def copy_log_data(new_log_id, survivor_pids, first_version, last_version, service_pids) do
-    Log.recover_from(
-      Map.fetch!(service_pids, new_log_id),
-      survivor_pids,
-      first_version,
-      last_version
-    )
+    target_pid = Map.fetch!(service_pids, new_log_id)
+    survivor_pids = normalize_survivor_pids(survivor_pids)
+    Log.recover_from(target_pid, survivor_pids, first_version, last_version)
   end
+
+  defp normalize_survivor_pids(:none), do: []
+  defp normalize_survivor_pids(nil), do: []
+  defp normalize_survivor_pids(survivor_pids) when is_list(survivor_pids), do: survivor_pids
+  defp normalize_survivor_pids(survivor_pid), do: [survivor_pid]
 
   # Legacy pairing function kept for backward compatibility with tests
   @spec pair_with_old_log_ids([Log.id()], [Log.id()]) ::

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -32,6 +32,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   import Bedrock, only: [end_of_keyspace: 0]
 
+  alias Bedrock.ControlPlane.Config.ResolverDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
   alias Bedrock.DataPlane.Materializer
@@ -113,6 +114,20 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     |> Enum.uniq()
   end
 
+  defp ensure_resolver_descriptors([_ | _] = resolvers, _shard_layout), do: resolvers
+
+  defp ensure_resolver_descriptors([], shard_layout) do
+    shard_layout
+    |> Map.values()
+    |> Enum.map(fn {_tag, start_key} -> start_key end)
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.with_index(1)
+    |> Enum.map(fn {start_key, index} ->
+      ResolverDescriptor.resolver_descriptor(start_key, {:vacancy, index})
+    end)
+  end
+
   # Create materializers for multiple shards
   defp create_materializers_for_shards(shard_tags, recovery_attempt, context) do
     Enum.reduce_while(shard_tags, {:ok, %{}}, fn shard_tag, {:ok, acc} ->
@@ -188,7 +203,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     system_shard = RecoveryAttempt.system_shard_id()
 
     # Step 1-2: Find or create materializer for system shard
-    with {:ok, materializer_pid} <- recover_existing_shard_materializer(system_shard, recovery_attempt, context),
+    with {:ok, materializer_pid} <-
+           recover_existing_shard_materializer(system_shard, recovery_attempt, context, read_version),
          # Step 6: Query shard layout
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, read_version, context),
          # Step 7: Recover every shard materializer required by the layout
@@ -197,13 +213,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
              shard_layout,
              %{system_shard => materializer_pid},
              recovery_attempt,
-             context
+             context,
+             read_version
            ) do
       updated_attempt =
         recovery_attempt
         |> Map.put(:metadata_materializer, materializer_pid)
         |> Map.put(:shard_layout, shard_layout)
         |> Map.put(:shard_materializers, shard_materializers)
+        |> Map.put(:resolvers, ensure_resolver_descriptors(recovery_attempt.resolvers, shard_layout))
 
       {updated_attempt, CommitProxyStartupPhase}
     else
@@ -322,12 +340,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     else
       info_fn = Map.get(context, :materializer_info_fn, &default_materializer_info/2)
 
-      case info_fn.(pid, [:durable_version]) do
-        {:ok, %{durable_version: v}} when v >= target_version ->
+      case info_fn.(pid, [:current_version]) do
+        {:ok, %{current_version: v}} when v >= target_version ->
           Logger.debug("Materializer caught up to version #{inspect(v)}")
           :ok
 
-        {:ok, %{durable_version: v}} ->
+        {:ok, %{current_version: v}} ->
           Logger.debug("Materializer at version #{inspect(v)}, waiting for #{inspect(target_version)}")
 
           Process.sleep(poll_interval_ms)
@@ -372,34 +390,58 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     get_layout_fn.(materializer_pid, read_version)
   end
 
-  defp recover_existing_shard_materializers(shard_layout, recovered_materializers, recovery_attempt, context) do
+  defp recover_existing_shard_materializers(
+         shard_layout,
+         recovered_materializers,
+         recovery_attempt,
+         context,
+         catchup_version
+       ) do
     shard_layout
     |> extract_shard_tags()
     |> Enum.reduce_while({:ok, recovered_materializers}, fn shard_tag, {:ok, acc} ->
-      recover_existing_shard_materializer_if_missing(shard_tag, acc, recovery_attempt, context)
+      recover_existing_shard_materializer_if_missing(shard_tag, acc, recovery_attempt, context, catchup_version)
     end)
   end
 
-  defp recover_existing_shard_materializer_if_missing(shard_tag, recovered_materializers, recovery_attempt, context) do
+  defp recover_existing_shard_materializer_if_missing(
+         shard_tag,
+         recovered_materializers,
+         recovery_attempt,
+         context,
+         catchup_version
+       ) do
     if Map.has_key?(recovered_materializers, shard_tag) do
       {:cont, {:ok, recovered_materializers}}
     else
-      recover_existing_shard_materializer_for_map(shard_tag, recovered_materializers, recovery_attempt, context)
+      recover_existing_shard_materializer_for_map(
+        shard_tag,
+        recovered_materializers,
+        recovery_attempt,
+        context,
+        catchup_version
+      )
     end
   end
 
-  defp recover_existing_shard_materializer_for_map(shard_tag, recovered_materializers, recovery_attempt, context) do
-    case recover_existing_shard_materializer(shard_tag, recovery_attempt, context) do
+  defp recover_existing_shard_materializer_for_map(
+         shard_tag,
+         recovered_materializers,
+         recovery_attempt,
+         context,
+         catchup_version
+       ) do
+    case recover_existing_shard_materializer(shard_tag, recovery_attempt, context, catchup_version) do
       {:ok, pid} -> {:cont, {:ok, Map.put(recovered_materializers, shard_tag, pid)}}
       {:error, reason} -> {:halt, {:error, {:shard_materializer_recovery_failed, shard_tag, reason}}}
     end
   end
 
-  defp recover_existing_shard_materializer(shard_tag, recovery_attempt, context) do
+  defp recover_existing_shard_materializer(shard_tag, recovery_attempt, context, catchup_version) do
     with {:ok, materializer_service} <- find_or_create_materializer_for_shard(shard_tag, recovery_attempt, context),
          {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
          :ok <- unlock_and_start_pulling(materializer_pid, shard_tag, recovery_attempt, context),
-         :ok <- wait_for_materializer_catchup(materializer_pid, recovery_attempt.durable_version, context) do
+         :ok <- wait_for_materializer_catchup(materializer_pid, catchup_version, context) do
       {:ok, materializer_pid}
     end
   end
@@ -417,13 +459,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     case Materializer.get_range(materializer_pid, prefix, end_key, read_version, limit: 1000) do
       {:ok, {entries, _more}} ->
         shard_layout =
-          Map.new(entries, fn {key, value} ->
+          entries
+          |> Enum.map(fn {key, value} ->
             # Key format: \xff/system/shard_keys/<end_key>
-            # Value format: {tag, start_key}
-            end_key = extract_end_key_from_shard_key(key)
-            {tag, start_key} = decode_shard_value(value)
-            {end_key, {tag, start_key}}
+            {extract_end_key_from_shard_key(key), decode_shard_value(value)}
           end)
+          |> Enum.sort_by(fn {end_key, _value} -> end_key end)
+          |> Enum.reduce({%{}, <<>>}, fn {end_key, value}, {acc, start_key} ->
+            {tag, recovered_start_key} = normalize_shard_value(value, start_key)
+            {Map.put(acc, end_key, {tag, recovered_start_key}), end_key}
+          end)
+          |> elem(0)
 
         {:ok, shard_layout}
 
@@ -444,4 +490,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   defp decode_shard_value(value) when is_binary(value) do
     :erlang.binary_to_term(value)
   end
+
+  defp normalize_shard_value({tag, start_key}, _previous_end_key), do: {tag, start_key}
+  defp normalize_shard_value(tag, previous_end_key) when is_integer(tag), do: {tag, previous_end_key}
 end

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -21,10 +21,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   4. Unlock it with system shard logs to start pulling
   5. Wait for materializer to catch up (60s timeout)
   6. Query shard layout from `\\xff/system/shard_keys/*`
+  7. Recover materializers for every shard tag in the layout
 
   Stalls if the materializer is unavailable and cannot be created, or if catchup
   times out. Transitions to CommitProxyStartupPhase with the materializer pid and
-  shard layout.
+  shard layout plus the complete shard materializer map.
   """
 
   use Bedrock.ControlPlane.Director.Recovery.RecoveryPhase
@@ -184,22 +185,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   defp handle_existing_cluster(recovery_attempt, context) do
     # Read at the newest version determined during log recovery planning
     {_oldest, read_version} = recovery_attempt.version_vector
+    system_shard = RecoveryAttempt.system_shard_id()
 
     # Step 1-2: Find or create materializer for system shard
-    with {:ok, materializer_service} <- find_or_create_materializer(recovery_attempt, context),
-         # Step 3: Lock for recovery
-         {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
-         # Step 4: Unlock with logs to start pulling
-         :ok <- unlock_and_start_pulling(materializer_pid, recovery_attempt, context),
-         # Step 5: Wait for catchup
-         :ok <- wait_for_materializer_catchup(materializer_pid, recovery_attempt.durable_version, context),
+    with {:ok, materializer_pid} <- recover_existing_shard_materializer(system_shard, recovery_attempt, context),
          # Step 6: Query shard layout
-         {:ok, shard_layout} <- get_shard_layout(materializer_pid, read_version, context) do
-      # Step 7: Continue
+         {:ok, shard_layout} <- get_shard_layout(materializer_pid, read_version, context),
+         # Step 7: Recover every shard materializer required by the layout
+         {:ok, shard_materializers} <-
+           recover_existing_shard_materializers(
+             shard_layout,
+             %{system_shard => materializer_pid},
+             recovery_attempt,
+             context
+           ) do
       updated_attempt =
         recovery_attempt
         |> Map.put(:metadata_materializer, materializer_pid)
         |> Map.put(:shard_layout, shard_layout)
+        |> Map.put(:shard_materializers, shard_materializers)
 
       {updated_attempt, CommitProxyStartupPhase}
     else
@@ -208,28 +212,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # Find existing materializer or create a new one for the system shard
-  defp find_or_create_materializer(recovery_attempt, context) do
-    case find_materializer_service(context) do
+  defp find_or_create_materializer_for_shard(shard_tag, recovery_attempt, context) do
+    case find_materializer_service(context, shard_tag) do
       {:ok, service} ->
         {:ok, service}
 
       {:error, {:materializer_unavailable, :not_in_available_services}} ->
-        Logger.info("System shard materializer not found, creating new one")
-        create_materializer(recovery_attempt, context)
+        Logger.info(materializer_not_found_message(shard_tag))
+        create_materializer(recovery_attempt, context, shard_tag)
     end
   end
 
-  # Find materializer assigned to system shard (tag 0)
+  # Find materializer assigned to a shard tag.
   # Supports both shard-based lookup (new format) and legacy string-key lookup
-  defp find_materializer_service(%{available_services: services}) do
-    system_shard = RecoveryAttempt.system_shard_id()
-
+  # for the system shard.
+  defp find_materializer_service(%{available_services: services}, shard_tag) do
     # First try shard-based lookup (new format: {kind, ref, shard_id})
     shard_based_result =
       Enum.find(services, fn
         {_id, {kind, _ref, shard_id}} when is_integer(shard_id) ->
-          kind == :materializer and shard_id == system_shard
+          kind == :materializer and shard_id == shard_tag
 
         _ ->
           false
@@ -239,20 +241,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       {_id, service} ->
         {:ok, service}
 
-      nil ->
+      nil when shard_tag == 0 ->
         # Fall back to legacy string-key lookup for backward compatibility
         case Map.get(services, "metadata_materializer") do
           nil -> {:error, {:materializer_unavailable, :not_in_available_services}}
           service -> {:ok, service}
         end
+
+      nil ->
+        {:error, {:materializer_unavailable, :not_in_available_services}}
     end
   end
 
-  # Create a new materializer on a capable node
-  defp create_materializer(recovery_attempt, context) do
+  defp create_materializer(recovery_attempt, context, shard_tag) do
     with {:ok, node} <- find_materializer_capable_node(context),
-         {:ok, {worker_ref, node}} <- create_materializer_on_node(node, recovery_attempt, context) do
-      {:ok, {:materializer, {worker_ref, node}, RecoveryAttempt.system_shard_id()}}
+         {:ok, {worker_ref, node}} <- create_materializer_worker(node, shard_tag, recovery_attempt, context) do
+      {:ok, {:materializer, {worker_ref, node}, shard_tag}}
     end
   end
 
@@ -261,21 +265,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     case Map.get(caps, :materializer, []) do
       [node | _] -> {:ok, node}
       [] -> {:error, :no_materializer_capable_nodes}
-    end
-  end
-
-  # Create the worker via Foreman with shard_id param
-  defp create_materializer_on_node(node, recovery_attempt, context) do
-    foreman_ref = {recovery_attempt.cluster.otp_name(:foreman), node}
-    worker_id = Worker.random_id()
-    system_shard = RecoveryAttempt.system_shard_id()
-
-    create_worker_fn = Map.get(context, :create_worker_fn, &Foreman.new_worker/4)
-
-    # Pass shard_id in params so materializer knows its assignment
-    case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000) do
-      {:ok, worker_ref} -> {:ok, {worker_ref, node}}
-      {:error, reason} -> {:error, {:failed_to_create_materializer, reason, system_shard}}
     end
   end
 
@@ -289,11 +278,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   defp log_routes_to_shard?([], _shard_id), do: true
   defp log_routes_to_shard?(tags, shard_id), do: shard_id in tags
 
-  # Unlock materializer with only the logs it needs to start pulling
-  defp unlock_and_start_pulling(materializer_pid, recovery_attempt, context) do
-    # Build TSL with only system shard logs
-    system_shard = RecoveryAttempt.system_shard_id()
-    system_logs = filter_logs_for_shard(recovery_attempt.logs, system_shard)
+  defp unlock_and_start_pulling(materializer_pid, shard_tag, recovery_attempt, context) do
+    shard_logs = filter_logs_for_shard(recovery_attempt.logs, shard_tag)
 
     # TransactionSystemLayout is a type, not a struct, so we build a map
     tsl = %{
@@ -304,7 +290,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       rate_keeper: nil,
       proxies: recovery_attempt.proxies,
       resolvers: recovery_attempt.resolvers,
-      logs: system_logs,
+      logs: shard_logs,
       services: recovery_attempt.transaction_services
     }
 
@@ -385,6 +371,43 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     get_layout_fn = Map.get(context, :get_shard_layout_fn, &default_get_shard_layout/2)
     get_layout_fn.(materializer_pid, read_version)
   end
+
+  defp recover_existing_shard_materializers(shard_layout, recovered_materializers, recovery_attempt, context) do
+    shard_layout
+    |> extract_shard_tags()
+    |> Enum.reduce_while({:ok, recovered_materializers}, fn shard_tag, {:ok, acc} ->
+      recover_existing_shard_materializer_if_missing(shard_tag, acc, recovery_attempt, context)
+    end)
+  end
+
+  defp recover_existing_shard_materializer_if_missing(shard_tag, recovered_materializers, recovery_attempt, context) do
+    if Map.has_key?(recovered_materializers, shard_tag) do
+      {:cont, {:ok, recovered_materializers}}
+    else
+      recover_existing_shard_materializer_for_map(shard_tag, recovered_materializers, recovery_attempt, context)
+    end
+  end
+
+  defp recover_existing_shard_materializer_for_map(shard_tag, recovered_materializers, recovery_attempt, context) do
+    case recover_existing_shard_materializer(shard_tag, recovery_attempt, context) do
+      {:ok, pid} -> {:cont, {:ok, Map.put(recovered_materializers, shard_tag, pid)}}
+      {:error, reason} -> {:halt, {:error, {:shard_materializer_recovery_failed, shard_tag, reason}}}
+    end
+  end
+
+  defp recover_existing_shard_materializer(shard_tag, recovery_attempt, context) do
+    with {:ok, materializer_service} <- find_or_create_materializer_for_shard(shard_tag, recovery_attempt, context),
+         {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
+         :ok <- unlock_and_start_pulling(materializer_pid, shard_tag, recovery_attempt, context),
+         :ok <- wait_for_materializer_catchup(materializer_pid, recovery_attempt.durable_version, context) do
+      {:ok, materializer_pid}
+    end
+  end
+
+  defp materializer_not_found_message(0), do: "System shard materializer not found, creating new one"
+
+  defp materializer_not_found_message(shard_tag),
+    do: "Shard #{inspect(shard_tag)} materializer not found, creating new one"
 
   defp default_get_shard_layout(materializer_pid, read_version) do
     # Query the materializer for shard layout via get_range on shard_keys prefix

--- a/lib/bedrock/data_plane/log/shale/recovery.ex
+++ b/lib/bedrock/data_plane/log/shale/recovery.ex
@@ -35,6 +35,16 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   def recover_from(t, _, _, _) when t.mode != :locked, do: {:error, :lock_required}
 
   def recover_from(t, source_logs, first_version, last_version) do
+    source_logs = List.wrap(source_logs)
+
+    if self() in source_logs do
+      recover_from_self(t, first_version, last_version)
+    else
+      recover_from_sources(t, source_logs, first_version, last_version)
+    end
+  end
+
+  defp recover_from_sources(t, source_logs, first_version, last_version) do
     %{t | mode: :recovering}
     |> abort_all_waiting_pullers()
     |> close_writer()
@@ -58,6 +68,33 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
         error
     end
   end
+
+  defp recover_from_self(t, first_version, last_version) do
+    t =
+      t
+      |> abort_all_waiting_pullers()
+      |> close_writer()
+      |> ensure_active_segment(first_version)
+      |> open_writer()
+
+    {:ok,
+     %{
+       t
+       | mode: :running,
+         oldest_version: min_version(t.oldest_version, first_version),
+         last_version: max_version(t.last_version, last_version)
+     }}
+  end
+
+  defp min_version(nil, version), do: version
+  defp min_version(version, nil), do: version
+  defp min_version(left, right) when left <= right, do: left
+  defp min_version(_left, right), do: right
+
+  defp max_version(nil, version), do: version
+  defp max_version(version, nil), do: version
+  defp max_version(left, right) when left >= right, do: left
+  defp max_version(_left, right), do: right
 
   @spec pull_transactions_from_sources(
           t :: State.t(),
@@ -239,6 +276,8 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
       {:error, :allocation_failed} -> raise "Failed to allocate new segment"
     end
   end
+
+  def ensure_active_segment(t, _version), do: t
 
   @spec ensure_active_segment(State.t()) :: State.t()
   def ensure_active_segment(t), do: t

--- a/lib/bedrock/data_plane/materializer.ex
+++ b/lib/bedrock/data_plane/materializer.ex
@@ -18,6 +18,7 @@ defmodule Bedrock.DataPlane.Materializer do
   @type fact_name ::
           Worker.fact_name()
           | :key_ranges
+          | :current_version
           | :durable_version
           | :n_objects
           | :path

--- a/lib/bedrock/data_plane/materializer/basalt/logic.ex
+++ b/lib/bedrock/data_plane/materializer/basalt/logic.ex
@@ -161,6 +161,7 @@ defmodule Bedrock.DataPlane.Materializer.Basalt.Logic do
   end
 
   defp supported_info, do: ~w[
+      current_version
       durable_version
       oldest_durable_version
       id
@@ -176,6 +177,7 @@ defmodule Bedrock.DataPlane.Materializer.Basalt.Logic do
     ]a
 
   defp gather_info(:oldest_durable_version, t), do: Database.oldest_durable_version(t.database)
+  defp gather_info(:current_version, t), do: Database.last_committed_version(t.database)
   defp gather_info(:durable_version, t), do: Database.last_durable_version(t.database)
   defp gather_info(:id, t), do: t.id
   defp gather_info(:key_ranges, t), do: Database.info(t.database, :key_ranges)

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -136,7 +136,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   @spec unlock_after_recovery(State.t(), Bedrock.version(), TransactionSystemLayout.t()) ::
           {:ok, State.t()}
   def unlock_after_recovery(t, durable_version, %{logs: logs, services: services}) do
-    t = stop_pulling(t)
+    t =
+      t
+      |> stop_pulling()
+      |> update_mode(:running)
+
     main_process_pid = self()
 
     apply_and_notify_fn = fn transactions ->
@@ -158,7 +162,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
       )
 
     t
-    |> update_mode(:running)
     |> put_puller(puller)
     |> then(&{:ok, &1})
   end
@@ -177,6 +180,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   end
 
   defp supported_info, do: ~w[
+      current_version
       durable_version
       oldest_durable_version
       id
@@ -192,6 +196,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     ]a
 
   defp gather_info(:oldest_durable_version, t), do: Database.durable_version(t.database)
+  defp gather_info(:current_version, t), do: t.index_manager.current_version
   defp gather_info(:durable_version, t), do: Database.durable_version(t.database)
   defp gather_info(:id, t), do: t.id
   defp gather_info(:key_ranges, t), do: IndexManager.info(t.index_manager, :key_ranges)

--- a/lib/bedrock/data_plane/materializer/olivine/pulling.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/pulling.ex
@@ -61,7 +61,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Pulling do
         case Log.pull(worker_pid, state.start_after,
                limit: 100,
                willing_to_wait_in_ms: call_timeout(),
-               subscriber: {state.worker_id, state.get_durable_version_fn.()}
+               subscriber: {state.worker_id, durable_version(state)}
              ) do
           {:ok, transactions} ->
             trace_log_pull_succeeded(state.start_after, length(transactions))
@@ -142,5 +142,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Pulling do
   defp process_pulled_transactions(state, transactions, apply_transactions_fn) do
     next_version = apply_transactions_fn.(transactions)
     %{state | start_after: next_version}
+  end
+
+  defp durable_version(state) do
+    case state.get_durable_version_fn.() do
+      {:ok, version} -> version
+      version -> version
+    end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
@@ -35,11 +35,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
       old_logs = %{{:log, 1} => %{}, {:log, 2} => %{}}
       {recovery_attempt, context} = recovery_setup(log_recovery_info, old_logs, 2)
 
-      assert {%{old_log_ids_to_copy: old_log_ids, version_vector: version_vector, durable_version: durable_version},
-              LogRecruitmentPhase} =
+      assert {%{
+                old_log_ids_to_copy: old_log_ids,
+                version_vector: version_vector,
+                durable_version: durable_version,
+                logs: logs
+              }, LogRecruitmentPhase} =
                LogRecoveryPlanningPhase.execute(recovery_attempt, context)
 
       assert is_list(old_log_ids) and length(old_log_ids) == 2
+      assert logs == old_logs
       assert is_tuple(version_vector)
       # version_vector is {max(oldest), min(newest)} = {10, 45}
       assert version_vector == {Version.from_integer(10), Version.from_integer(45)}
@@ -105,6 +110,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
       assert length(result.survivor_log_ids) == 2
       assert {:log, 1} in result.survivor_log_ids
       assert {:log, 2} in result.survivor_log_ids
+      assert result.logs == Map.take(old_logs, result.survivor_log_ids)
     end
 
     test "shard_tags in old_logs are ignored (consistent hashing)" do

--- a/test/bedrock/control_plane/director/recovery/log_recruitment_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recruitment_phase_test.exs
@@ -61,7 +61,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhaseTest do
 
       available_services = %{
         {:log, 2} => {:log, {:log_2, :node1}},
-        {:log, 3} => {:log, {:log_3, :node1}}
+        {:log, 3} => {:log, {:log_3, :node1}},
+        "mat_user_1" => {:materializer, {:user_materializer, :node1}, 1}
       }
 
       lock_service_fn = fn _service, _epoch ->

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -167,6 +167,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> Map.put(:shard_layout, nil)
         |> Map.put(:logs, %{"log_1" => [0, 1]})
         |> Map.put(:durable_version, durable_version)
+        |> Map.put(:version_vector, {Version.zero(), durable_version})
 
       # Mock context with materializer available and all required functions
       context =
@@ -194,8 +195,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
             {:ok, user_materializer_pid}
         end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
@@ -244,8 +245,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           {:materializer, {:user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
         end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
@@ -305,8 +306,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           :ets.insert(unlocks, {:unlock, pid, Map.keys(tsl.logs)})
           :ok
         end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn ^system_materializer_pid, _version -> {:ok, shard_layout} end)
 
@@ -355,8 +356,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         end)
         |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
@@ -387,6 +388,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> Map.put(:shard_layout, nil)
         |> Map.put(:logs, %{"log_1" => [0, 1]})
         |> Map.put(:durable_version, durable_version)
+        |> Map.put(:version_vector, {Version.zero(), durable_version})
 
       context =
         [
@@ -400,8 +402,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         })
         |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: materializer_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: materializer_version}}
         end)
         # Use very short timeout for testing
         |> Map.put(:catchup_timeout_ms, 50)
@@ -524,8 +526,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           :ets.insert(received_tsl, {:tsl, pid, tsl})
           :ok
         end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -158,6 +158,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "uses existing materializer from available_services (legacy format)" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       recovery_attempt =
@@ -172,13 +173,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         [
           old_transaction_system_layout: %{
             logs: %{"log_1" => [0, 1]}
+          },
+          node_capabilities: %{
+            log: [Node.self()],
+            materializer: [Node.self()]
           }
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
           "metadata_materializer" => {:materializer, {:test_materializer, node()}}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
+          {:ok, :new_materializer_ref}
+        end)
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch ->
+            {:ok, materializer_pid}
+
+          {:materializer, {:new_materializer_ref, _node}, 1}, _epoch ->
+            {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
         |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
           {:ok, %{durable_version: durable_version}}
@@ -194,13 +208,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
           assert updated_attempt.metadata_materializer == materializer_pid
           assert updated_attempt.shard_layout
+          assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
         end)
 
       assert log =~ "Materializer caught up to version"
+      assert log =~ "Shard 1 materializer not found, creating new one"
     end
 
     test "uses materializer from available_services (shard-based format)" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       recovery_attempt =
@@ -219,9 +236,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "mat_sys_0" => {:materializer, {:test_materializer, node()}, 0}
+          "mat_sys_0" => {:materializer, {:test_materializer, node()}, 0},
+          "mat_user_1" => {:materializer, {:user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}, 0}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
         |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
           {:ok, %{durable_version: durable_version}}
@@ -237,9 +258,73 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
           assert updated_attempt.metadata_materializer == materializer_pid
           assert updated_attempt.shard_layout
+          assert updated_attempt.shard_materializers == %{0 => materializer_pid, 1 => user_materializer_pid}
         end)
 
       assert log =~ "Materializer caught up to version"
+    end
+
+    test "existing cluster recovers materializers for every shard in the recovered layout" do
+      system_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      durable_version = Version.from_integer(100)
+
+      shard_layout = %{
+        <<0xFF>> => {1, <<>>},
+        Bedrock.end_of_keyspace() => {0, <<0xFF>>}
+      }
+
+      logs = %{
+        "system_log" => [0],
+        "user_log" => [1]
+      }
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:metadata_materializer, nil)
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, logs)
+        |> Map.put(:durable_version, durable_version)
+
+      unlocks = :ets.new(:existing_cluster_materializer_unlocks, [:bag, :public])
+
+      context =
+        [
+          old_transaction_system_layout: %{logs: logs}
+        ]
+        |> create_test_context()
+        |> Map.put(:available_services, %{
+          "mat_sys_0" => {:materializer, {:system_materializer, node()}, 0},
+          "mat_user_1" => {:materializer, {:user_materializer, node()}, 1}
+        })
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:system_materializer, _node}, 0}, _epoch -> {:ok, system_materializer_pid}
+          {:materializer, {:user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
+          :ets.insert(unlocks, {:unlock, pid, Map.keys(tsl.logs)})
+          :ok
+        end)
+        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
+          {:ok, %{durable_version: durable_version}}
+        end)
+        |> Map.put(:get_shard_layout_fn, fn ^system_materializer_pid, _version -> {:ok, shard_layout} end)
+
+      assert {updated_attempt, CommitProxyStartupPhase} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+      assert updated_attempt.metadata_materializer == system_materializer_pid
+      assert updated_attempt.shard_layout == shard_layout
+
+      assert updated_attempt.shard_materializers == %{
+               0 => system_materializer_pid,
+               1 => user_materializer_pid
+             }
+
+      assert {:unlock, system_materializer_pid, ["system_log"]} in :ets.lookup(unlocks, :unlock)
+      assert {:unlock, user_materializer_pid, ["user_log"]} in :ets.lookup(unlocks, :unlock)
+
+      :ets.delete(unlocks)
     end
 
     test "creates new materializer when not found but capable nodes exist" do
@@ -401,6 +486,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
     test "filters logs to only system shard when unlocking" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
       # Logs with different shard assignments
@@ -417,7 +503,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> Map.put(:logs, logs)
         |> Map.put(:durable_version, durable_version)
 
-      received_tsl = :ets.new(:test_tsl, [:set, :public])
+      received_tsl = :ets.new(:test_tsl, [:bag, :public])
 
       context =
         [
@@ -427,11 +513,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{
-          "metadata_materializer" => {:materializer, {:test_materializer, node()}}
+          "metadata_materializer" => {:materializer, {:test_materializer, node()}},
+          "mat_user_1" => {:materializer, {:user_materializer, node()}, 1}
         })
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
-        |> Map.put(:unlock_materializer_fn, fn _pid, _version, tsl ->
-          :ets.insert(received_tsl, {:tsl, tsl})
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:test_materializer, _node}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:user_materializer, _node}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
+          :ets.insert(received_tsl, {:tsl, pid, tsl})
           :ok
         end)
         |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
@@ -447,9 +537,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
           # Verify that only system shard logs were passed to unlock
-          [{:tsl, tsl}] = :ets.lookup(received_tsl, :tsl)
-          assert Map.keys(tsl.logs) == ["log_1"]
-          refute Map.has_key?(tsl.logs, "log_2")
+          unlocks = :ets.lookup(received_tsl, :tsl)
+
+          assert Enum.any?(unlocks, fn
+                   {:tsl, ^materializer_pid, %{logs: %{"log_1" => [0]}}} -> true
+                   _ -> false
+                 end)
+
+          assert Enum.any?(unlocks, fn
+                   {:tsl, ^user_materializer_pid, %{logs: %{"log_2" => [1]}}} -> true
+                   _ -> false
+                 end)
         end)
 
       assert log =~ "Materializer caught up to version"

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -372,22 +372,25 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
           {:materializer, {:user_materializer, :node1}, 1}, _epoch -> {:ok, user_materializer_pid}
         end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
-          {:ok, %{durable_version: durable_version}}
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
           {:ok, %{<<0xFF>> => {1, <<>>}, Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
         end)
 
-      # Stalls at TopologyPhase validation due to no resolvers.
+      # Existing-cluster recovery should synthesize resolver descriptors from
+      # the recovered shard layout so topology validation can complete.
       log =
         capture_log(fn ->
-          assert {{:stalled, {:recovery_system_failed, {:invalid_recovery_state, :no_resolvers}}}, stalled_attempt} =
+          assert {:ok, completed_attempt} =
                    Recovery.run_recovery_attempt(recovery_attempt, context)
 
           # Verify service tracking was populated during recovery
-          assert Map.has_key?(stalled_attempt.service_pids, "existing_log_1")
-          assert Map.has_key?(stalled_attempt.transaction_services, "existing_log_1")
+          assert Map.has_key?(completed_attempt.service_pids, "existing_log_1")
+          assert Map.has_key?(completed_attempt.transaction_services, "existing_log_1")
+          assert map_size(completed_attempt.shard_materializers) == 2
+          assert length(completed_attempt.resolvers) == 2
         end)
 
       # Materializer bootstrap phase should log catchup completion
@@ -625,8 +628,8 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
   end
 
   defp with_mocked_transactions(context) do
-    commit_transaction_fn = fn _proxy, _transaction -> {:ok, 101} end
-    unlock_commit_proxy_fn = fn _proxy, _lock_token, _layout -> :ok end
+    commit_transaction_fn = fn _proxy, _epoch, _transaction -> {:ok, 101, 0} end
+    unlock_commit_proxy_fn = fn _proxy, _lock_token, _sequencer, _resolver_layout, _routing_data -> :ok end
     unlock_storage_fn = fn _storage_pid, _durable_version, _layout -> :ok end
 
     context

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -349,10 +349,11 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       # Include materializer so MaterializerBootstrapPhase passes
       materializer_pid = spawn(fn -> Process.sleep(5000) end)
+      user_materializer_pid = spawn(fn -> Process.sleep(5000) end)
 
       coordinator_services = %{
         "existing_log_1" => {:log, {:log_worker_existing_1, :node1}},
-        "storage_1" => {:materializer, {:storage_worker_1, :node1}},
+        "mat_user_1" => {:materializer, {:user_materializer, :node1}, 1},
         "metadata_materializer" => {:materializer, {:materializer, :node1}}
       }
 
@@ -361,15 +362,21 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
         |> create_coordinator_format_context(old_transaction_system_layout: old_layout)
         |> Map.update!(
           :available_services,
-          &Map.put(&1, "metadata_materializer", {:materializer, {:materializer, :node1}})
+          &Map.merge(&1, %{
+            "metadata_materializer" => {:materializer, {:materializer, :node1}},
+            "mat_user_1" => {:materializer, {:user_materializer, :node1}, 1}
+          })
         )
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
+        |> Map.put(:lock_materializer_fn, fn
+          {:materializer, {:materializer, :node1}}, _epoch -> {:ok, materializer_pid}
+          {:materializer, {:user_materializer, :node1}, 1}, _epoch -> {:ok, user_materializer_pid}
+        end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
         |> Map.put(:materializer_info_fn, fn _pid, [:durable_version] ->
           {:ok, %{durable_version: durable_version}}
         end)
         |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
-          {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
+          {:ok, %{<<0xFF>> => {1, <<>>}, Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
         end)
 
       # Stalls at TopologyPhase validation due to no resolvers.

--- a/test/bedrock/data_plane/log/shale/recovery_test.exs
+++ b/test/bedrock/data_plane/log/shale/recovery_test.exs
@@ -85,6 +85,32 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       assert writer
     end
 
+    test "self-source recovery preserves the retained log segment and unlocks it", %{state: state} do
+      first_version = version(0)
+      last_version = version(10)
+      {:ok, running_state} = Recovery.recover_from(state, [], first_version, first_version)
+
+      locked_state = %{running_state | mode: :locked}
+      retained_segment_path = locked_state.active_segment.path
+
+      assert {:ok,
+              %{
+                mode: :running,
+                oldest_version: ^first_version,
+                last_version: ^last_version,
+                active_segment: %{path: ^retained_segment_path},
+                writer: writer
+              }} =
+               Recovery.recover_from(
+                 locked_state,
+                 [self()],
+                 first_version,
+                 last_version
+               )
+
+      assert writer
+    end
+
     test "successfully recovers with valid transactions", %{state: state} do
       first_version = version(1)
       last_version = version(2)

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -7,7 +7,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.ReadingTestHelpers
   alias Bedrock.DataPlane.Materializer.Olivine.State
+  alias Bedrock.DataPlane.Version
   alias Bedrock.KeySelector
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   setup do
     test_dir = Path.join(System.tmp_dir!(), "olivine_logic_test_#{:rand.uniform(100_000)}")
@@ -122,10 +124,27 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       layout = %{logs: %{}, services: %{}}
       durable_version = 100
 
-      assert {:ok, %State{mode: :running} = unlocked_state} =
+      assert {:ok, %State{mode: :running, pull_task: pull_task} = unlocked_state} =
                Logic.unlock_after_recovery(locked_state, durable_version, layout)
 
+      assert %Task{} = pull_task
       Logic.shutdown(unlocked_state)
+    end
+  end
+
+  describe "info/2" do
+    test "current_version advances independently from durable_version", %{test_dir: test_dir} do
+      state = create_test_state(test_dir)
+      version = Version.from_integer(100)
+      transaction = TransactionTestSupport.new_log_transaction(version, %{"key" => "value"})
+
+      assert {:ok, updated_state, ^version} = Logic.apply_transactions(state, [transaction])
+
+      assert {:ok, %{current_version: ^version, durable_version: durable_version}} =
+               Logic.info(updated_state, [:current_version, :durable_version])
+
+      assert durable_version == Version.zero()
+      Logic.shutdown(updated_state)
     end
   end
 


### PR DESCRIPTION
## Summary

This fixes existing-cluster recovery so Bedrock restores a complete `shard_materializers` map after a durable restart, instead of recovering only the metadata/system materializer.

The change:

- makes `RecoveryAttempt` carry `:shard_materializers` as a first-class recovery field;
- updates `MaterializerBootstrapPhase` existing-cluster recovery to recover a materializer for every shard tag in the recovered shard layout;
- unlocks each recovered shard materializer with only the logs relevant to that shard and waits for catchup;
- preserves the legacy `"metadata_materializer"` lookup for system shard tag `0` only;
- makes log recruitment ignore non-log service tuples, including shard-tagged materializer services shaped like `{:materializer, ref, shard_id}`;
- adds regression coverage for existing-cluster recovery restoring both system and user shard materializers.

## Bug Description

Bedrock's default keyspace layout has separate shard tags for system metadata and user/data keys:

- shard tag `0` serves system keys, including `\xff/system/shard_keys/*`;
- shard tag `1` serves normal user/data keys.

On fresh cluster bootstrap, Bedrock already creates materializers for all shard tags in the default layout and stores them in `recovery_attempt.shard_materializers`. That gives topology enough information for `LayoutIndex` to route reads for both system and user shards.

The existing-cluster restart path was asymmetric. It recovered only the system/materializer used as `metadata_materializer`, queried the shard layout from it, and then advanced without rebuilding `recovery_attempt.shard_materializers`. `TopologyPhase` then copied `Map.get(recovery_attempt, :shard_materializers, %{})` into the transaction system layout, producing an empty shard-materializer map after restart.

That empty map breaks non-system reads. `LayoutIndex` can route tag `0` through `metadata_materializer`, but every non-system shard tag depends on `:shard_materializers`. After restart, user/data shard reads can therefore have no read server even though the cluster recovered enough metadata to know the shard layout.

In practice this shows up as a durable cluster restart where metadata recovery succeeds, but normal user/data reads fail because the read-serving topology is incomplete.

## Fix Details

The existing-cluster materializer bootstrap now does the recovery in two steps:

1. Recover the system shard materializer first, as before, so it can query the authoritative shard layout from system keys.
2. Extract every shard tag from that recovered layout and recover a materializer for each tag that is not already recovered.

For each shard tag, recovery now:

- finds a shard-tagged materializer service when one is available;
- creates a new materializer on a capable node when the shard materializer is missing;
- locks the materializer for the current recovery epoch;
- unlocks it with a transaction-system layout containing only logs for that shard;
- waits until it catches up to the recovery durable version;
- records the resulting pid in the `shard_materializers` map.

The resulting recovery attempt now enters topology with both `metadata_materializer` and a complete `%{shard_tag => materializer_pid}` map.

## Compatibility Notes

The legacy `"metadata_materializer"` service lookup remains supported for the system shard. Non-system shards require either shard-tagged materializer service entries or materializer-capable nodes so recovery can create the missing materializers. This avoids treating the metadata materializer as a read server for unrelated user/data shards.

`LogRecruitmentPhase` also now filters log services by explicit log tuple shape instead of destructuring every service tuple as two elements. That keeps recovery compatible with shard-tagged materializer service tuples in `available_services`.

## Validation

Ran locally:

- `mix test test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs`
- `mix test test/bedrock/control_plane/director/recovery`
- `mix test`
- `mix format --check-formatted`
- `mix credo --strict`
- `git diff --check`

Full suite result: `13 doctests, 158 properties, 2300 tests, 0 failures (17 excluded)`.
