### PR TITLE
Fix waitlisting with nil reply_fn in Olivine Reading (bedrock-66h)

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/reading.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/reading.ex
@@ -305,17 +305,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Reading do
   end
 
   defp handle_version_too_new(manager, error, request_args, timing, opts) do
+    reply_fn = opts[:reply_fn]
+
     case opts[:wait_ms] do
-      wait_ms when is_integer(wait_ms) and wait_ms > 0 ->
+      # A waitlisted request can only be delivered through its reply_fn, so
+      # waitlisting without one is meaningless: the caller could never be
+      # notified, and a nil reply_fn would crash notify_waiting_fetches and
+      # shutdown when they invoke it. Return the error immediately instead.
+      wait_ms when is_integer(wait_ms) and wait_ms > 0 and is_function(reply_fn, 1) ->
         timing = ReadRequest.mark_waitlisted(timing)
         fetch_request = build_waitlist_request(timing.operation, request_args)
 
-        # Store timing for when the waitlisted request is eventually processed
-        waitlist_key = {extract_version(request_args), opts[:reply_fn]}
-        Process.put({:waitlist_timing, waitlist_key}, timing)
-
         updated_manager =
-          add_to_waitlist(manager, fetch_request, extract_version(request_args), opts[:reply_fn], wait_ms)
+          add_to_waitlist(manager, fetch_request, extract_version(request_args), reply_fn, wait_ms)
 
         {updated_manager, :ok}
 

--- a/test/bedrock/data_plane/materializer/olivine/reading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/reading_test.exs
@@ -237,6 +237,58 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.ReadingTest do
                updated_manager.waiting_fetches[v2()]
     end
 
+    # Regression test for bedrock-66h: waitlisting a request that has wait_ms
+    # but no reply_fn used to queue a nil reply_fn. When the version was later
+    # applied, notify_waiting_fetches ran the fetch synchronously (nil reply_fn
+    # means "do now"), got {:ok, value} back, matched it against the {:ok, pid}
+    # clause in execute_fetch_request, and crashed in Process.monitor/1 with an
+    # ArgumentError. The fix rejects waitlisting without a reply_fn: the
+    # waitlist's only delivery mechanism IS reply_fn, so a caller that supplied
+    # none could never be notified anyway — it now gets the error immediately,
+    # exactly as if wait_ms had not been set. (The sole production caller,
+    # Olivine's Server, always supplies a reply_fn.)
+    test "with wait_ms but no reply_fn the error is returned immediately and nothing is waitlisted", %{
+      manager: manager,
+      context: context,
+      index_manager: index_manager,
+      database: database
+    } do
+      {manager_after_get, get_result} =
+        Reading.handle_get(manager, context, "key1", v2(), wait_ms: 5_000)
+
+      {manager_after_range, range_result} =
+        Reading.handle_get_range(manager_after_get, context, "range:a", "range:z", v2(), wait_ms: 5_000)
+
+      # Pre-fix, both requests were waitlisted with a nil reply_fn and this
+      # notification crashed with an ArgumentError in Process.monitor/1.
+      new_context = advance_to_v2(index_manager, database)
+      notified_manager = Reading.notify_waiting_fetches(manager_after_range, new_context, v2())
+
+      assert notified_manager.waiting_fetches == %{}
+      assert Reading.get_active_tasks(notified_manager) == MapSet.new()
+
+      # Post-fix, the caller gets the error straight back and no state changes.
+      assert get_result == {:error, :version_too_new}
+      assert range_result == {:error, :version_too_new}
+      assert manager_after_range.waiting_fetches == %{}
+    end
+
+    test "waitlisting does not leak :waitlist_timing process-dictionary entries", %{
+      manager: manager,
+      context: context
+    } do
+      {_manager, :ok} =
+        Reading.handle_get(manager, context, "key1", v2(), wait_ms: 5_000, reply_fn: fn _ -> :ok end)
+
+      timing_keys =
+        Enum.filter(Process.get_keys(), fn
+          {:waitlist_timing, _} -> true
+          _ -> false
+        end)
+
+      assert timing_keys == []
+    end
+
     test "without wait_ms the error is returned immediately", %{manager: manager, context: context} do
       assert {^manager, {:error, :version_too_new}} =
                Reading.handle_get(manager, context, "key1", v2(), [])


### PR DESCRIPTION
## Bug

`handle_version_too_new` in `lib/bedrock/data_plane/materializer/olivine/reading.ex` waitlisted a request whenever `wait_ms > 0`, even when `opts[:reply_fn]` was `nil`. When `notify_waiting_fetches` later processed such an entry, `execute_fetch_request(context, nil, ...)` invoked `execute_get`/`execute_get_range`, whose `do_now_or_async_with_reply(nil, fun)` ran the fetch **synchronously** and returned `{:ok, value}` — which then matched the unguarded `{:ok, pid}` clause in `execute_fetch_request` and crashed in `add_active_task` via `Process.monitor(value)`:

```
** (ArgumentError) errors were found at the given arguments:
  * 2nd argument: not a pid
    :erlang.monitor(:process, "value1")
    lib/bedrock/data_plane/materializer/olivine/reading.ex:348: add_active_task/2
```

Same bug class as PR #79, one layer down.

## Fix (option a: reject waitlisting without a reply_fn)

The waitlist's only delivery mechanism **is** `reply_fn` — a caller that supplied none could never be notified of the eventual result, and a `nil` entry would also crash `notify_waitlist_shutdown` and `execute_fetch_request`'s error branch, which call `reply_fn.(error)` unconditionally. So `handle_version_too_new` now only waitlists when `is_function(reply_fn, 1)`; otherwise the caller gets `{:error, :version_too_new}` immediately, exactly as if `wait_ms` had not been set. The sole production caller (Olivine `Server.handle_call` for `:get`/`:get_range`) always injects a `reply_fn`, so no legitimate path is affected. This was preferred over guarding the `{:ok, pid}` clauses (option b), which would have papered over a nonsensical waitlist entry rather than preventing it.

## `{:waitlist_timing, key}` leak

The process-dictionary write at waitlist time was never read or deleted anywhere — a pure leak. It was evidently meant to feed wait-duration telemetry when the waitlisted request was later processed, but wiring that up correctly would require consuming it in `notify_waiting_fetches` *and* on timeout expiry *and* at shutdown; the minimal correct change is to delete the dead write, which this PR does (with a regression test asserting no `{:waitlist_timing, _}` keys remain after waitlisting).

## TDD evidence

Regression tests written first and confirmed failing on the pre-fix code:
- nil-reply_fn waitlist test crashed with the exact `ArgumentError` in `Process.monitor/1` above
- pdict test found a leaked `{:waitlist_timing, {v2, #Function<...>}}` entry

Post-fix: `reading_test.exs` green at seeds 121194 and 42 (23 tests), olivine dir green (252 tests, 23 properties), full suite green (2348 tests, 158 properties, 13 doctests, 0 failures).

Closes bedrock-66h.