### PR TITLE
Let logs trim history once it's safely stored downstream (bedrock-q67.8)

### DIFF
--- a/lib/bedrock/data_plane/log.ex
+++ b/lib/bedrock/data_plane/log.ex
@@ -68,8 +68,8 @@ defmodule Bedrock.DataPlane.Log do
   @doc """
   Pull transactions from the log starting from a given version. Options allow
   specifying the maximum number of transactions to return, the last version
-  considered valid, whether the operation is recovery-related, subscriber
-  details to maintain state, and a timeout for the operation.
+  considered valid, whether the operation is recovery-related, an inline
+  durability report, and a timeout for the operation.
 
   Returns a list of transactions or an error indicating why the pull failed.
 
@@ -83,7 +83,13 @@ defmodule Bedrock.DataPlane.Log do
       - `last_version`: The last valid version for pulling transactions
         (inclusive).
       - `recovery`: Indicates if this pull is part of a recovery operation.
-      - `subscriber`: A tuple containing an ID and the last durable version.
+      - `durable_up_to`: Inline durability report: every transaction at or
+        below this version is durable downstream, so the log may trim history
+        strictly below it. The log keeps a single trim point (the monotonic
+        maximum of all reported values — reports that would regress it are
+        ignored); there is no per-consumer tracking, since each log has a
+        single durability-reporting consumer (its Demux). After reporting
+        `durable_up_to: v`, a puller must not ask for versions older than `v`.
       - `timeout_in_ms`: Timeout for the operation in milliseconds.
 
   ## Return Values:
@@ -105,7 +111,7 @@ defmodule Bedrock.DataPlane.Log do
             limit: pos_integer(),
             last_version: Bedrock.version(),
             recovery: boolean(),
-            subscriber: {subscriber_id :: String.t(), last_durable_version :: Bedrock.version()},
+            durable_up_to: Bedrock.version(),
             timeout_in_ms: Bedrock.timeout_in_ms()
           ]
         ) ::

--- a/lib/bedrock/data_plane/log.ex
+++ b/lib/bedrock/data_plane/log.ex
@@ -90,6 +90,11 @@ defmodule Bedrock.DataPlane.Log do
         ignored); there is no per-consumer tracking, since each log has a
         single durability-reporting consumer (its Demux). After reporting
         `durable_up_to: v`, a puller must not ask for versions older than `v`.
+        `v` must be the commit version of a transaction the log holds (or a
+        version at/past its tail): the log retains the segment containing the
+        trim point, but a report falling in the gap between two commit
+        versions may trim the preceding segment and make a subsequent pull
+        from exactly `v` fail with `:version_too_old`.
       - `timeout_in_ms`: Timeout for the operation in milliseconds.
 
   ## Return Values:

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -235,6 +235,8 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   def handle_call({:pull, from_version, opts}, from, t) do
     trace_pull_transactions(from_version, opts)
 
+    t = maybe_advance_min_durable_version(t, opts[:durable_up_to])
+
     case pull(t, from_version, opts) do
       {:ok, t, transactions} ->
         reply(t, {:ok, transactions})
@@ -376,6 +378,14 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     end
   end
 
+  # Inline durability report from `Log.pull/3`'s `:durable_up_to` option. A
+  # single trim point is kept per log (the monotonic maximum of all reports);
+  # there is no per-consumer tracking.
+  defp maybe_advance_min_durable_version(t, nil), do: t
+
+  defp maybe_advance_min_durable_version(t, durable_up_to) when is_binary(durable_up_to),
+    do: advance_min_durable_version(t, durable_up_to)
+
   defp advance_min_durable_version(t, incoming_version) do
     min_durable_version =
       case t.min_durable_version do
@@ -401,25 +411,37 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     segments_oldest_first = Enum.reverse(t.segments)
 
     {segments_to_trim_oldest_first, remaining_segments_oldest_first} =
-      Enum.split_while(segments_oldest_first, &segment_fully_durable?(&1, t.min_durable_version))
+      Enum.split_while(segments_oldest_first, &segment_fully_below_trim_point?(&1, t.min_durable_version))
 
-    Enum.each(segments_to_trim_oldest_first, fn segment ->
-      :ok = Segment.return_to_recycler(segment, t.segment_recycler)
-    end)
+    case segments_to_trim_oldest_first do
+      [] ->
+        t
 
-    remaining_segments = Enum.reverse(remaining_segments_oldest_first)
+      segments_to_trim ->
+        Enum.each(segments_to_trim, fn segment ->
+          :ok = Segment.return_to_recycler(segment, t.segment_recycler)
+        end)
 
-    t
-    |> Map.put(:segments, remaining_segments)
-    |> Map.put(:oldest_version, determine_oldest_version(t.active_segment, remaining_segments))
+        remaining_segments = Enum.reverse(remaining_segments_oldest_first)
+        trace_segments_trimmed(length(segments_to_trim), t.min_durable_version)
+
+        t
+        |> Map.put(:segments, remaining_segments)
+        |> Map.put(:oldest_version, determine_oldest_version(t.active_segment, remaining_segments))
+    end
   end
 
-  defp segment_fully_durable?(segment, min_durable_version) do
+  # A segment may be recycled only when every transaction it holds is strictly
+  # below the trim point. The segment containing the trim point itself is
+  # retained so that a pull for `start_after: trim_point` remains servable
+  # (the active write segment is structurally exempt: only `t.segments` are
+  # ever considered for trimming).
+  defp segment_fully_below_trim_point?(segment, min_durable_version) do
     loaded_segment = Segment.ensure_transactions_are_loaded(segment)
 
     case Segment.last_version(loaded_segment) do
       nil -> true
-      last_version -> last_version <= min_durable_version
+      last_version -> last_version < min_durable_version
     end
   end
 

--- a/lib/bedrock/data_plane/log/telemetry.ex
+++ b/lib/bedrock/data_plane/log/telemetry.ex
@@ -63,6 +63,15 @@ defmodule Bedrock.DataPlane.Log.Telemetry do
     )
   end
 
+  @spec trace_segments_trimmed(segments_trimmed :: pos_integer(), trim_point :: Bedrock.version()) :: :ok
+  def trace_segments_trimmed(segments_trimmed, trim_point) do
+    Telemetry.execute(
+      [:bedrock, :log, :segments_trimmed],
+      %{segments_trimmed: segments_trimmed},
+      Map.put(trace_metadata(), :trim_point, trim_point)
+    )
+  end
+
   @spec trace_pull_transactions(from_version :: Bedrock.version(), opts :: Keyword.t()) :: :ok
   def trace_pull_transactions(from_version, opts) do
     Telemetry.execute(

--- a/lib/bedrock/data_plane/log/tracing.ex
+++ b/lib/bedrock/data_plane/log/tracing.ex
@@ -18,7 +18,8 @@ defmodule Bedrock.DataPlane.Log.Tracing do
         [:bedrock, :log, :recover_from],
         [:bedrock, :log, :push],
         [:bedrock, :log, :push_out_of_order],
-        [:bedrock, :log, :pull]
+        [:bedrock, :log, :pull],
+        [:bedrock, :log, :segments_trimmed]
       ],
       &__MODULE__.handler/4,
       nil
@@ -68,6 +69,10 @@ defmodule Bedrock.DataPlane.Log.Tracing do
 
   def log_event(:pull, _, %{from_version: from_version, opts: opts}),
     do: info("Pull transactions from version #{Version.to_string(from_version)} with options #{inspect(opts)}")
+
+  def log_event(:segments_trimmed, %{segments_trimmed: segments_trimmed}, %{trim_point: trim_point}) do
+    info("Trimmed #{segments_trimmed} durable segment(s) below version #{Version.to_string(trim_point)}")
+  end
 
   defp info(message) do
     metadata = Logger.metadata()

--- a/lib/bedrock/data_plane/materializer/basalt/pulling.ex
+++ b/lib/bedrock/data_plane/materializer/basalt/pulling.ex
@@ -59,10 +59,14 @@ defmodule Bedrock.DataPlane.Materializer.Basalt.Pulling do
       {:ok, {log_id, %{status: {:up, worker_pid}}}} ->
         trace_log_pull_start(state.start_after, state.start_after)
 
+        # Note: materializers deliberately do not report `durable_up_to` here.
+        # The log keeps a single trim point (one Demux consumer per log);
+        # reporting from multiple materializers could trim history that a
+        # slower materializer still needs. Materializers move off the Log to
+        # the Demux in bedrock-q67.10.
         case Log.pull(worker_pid, state.start_after,
                limit: 100,
-               willing_to_wait_in_ms: call_timeout(),
-               subscriber: {"storage_server", state.get_durable_version_fn.()}
+               willing_to_wait_in_ms: call_timeout()
              ) do
           {:ok, encoded_transactions} ->
             trace_log_pull_succeeded(state.start_after, length(encoded_transactions))

--- a/lib/bedrock/data_plane/materializer/olivine/pulling.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/pulling.ex
@@ -63,10 +63,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Pulling do
       {:ok, {log_id, %{status: {:up, worker_pid}}}} ->
         trace_log_pull_start(state.start_after, state.start_after)
 
+        # Note: materializers deliberately do not report `durable_up_to` here.
+        # The log keeps a single trim point (one Demux consumer per log);
+        # reporting from multiple materializers could trim history that a
+        # slower materializer still needs. Materializers move off the Log to
+        # the Demux in bedrock-q67.10.
         case Log.pull(worker_pid, state.start_after,
                limit: 100,
-               willing_to_wait_in_ms: call_timeout(),
-               subscriber: {state.worker_id, state.get_durable_version_fn.()}
+               willing_to_wait_in_ms: call_timeout()
              ) do
           {:ok, transactions} ->
             trace_log_pull_succeeded(state.start_after, length(transactions))

--- a/test/bedrock/data_plane/log/shale/trimming_test.exs
+++ b/test/bedrock/data_plane/log/shale/trimming_test.exs
@@ -1,0 +1,327 @@
+defmodule Bedrock.DataPlane.Log.Shale.TrimmingTest do
+  @moduledoc """
+  Tests for inline durability reporting (`durable_up_to` on `Log.pull`) and
+  the automatic WAL segment trimming it drives.
+
+  All tests are driven by explicit pushes/pulls and synchronous calls — no
+  timing dependence.
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.Cluster
+  alias Bedrock.DataPlane.Log.Shale.Segment
+  alias Bedrock.DataPlane.Log.Shale.Server
+  alias Bedrock.DataPlane.Log.Shale.Writer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    otp_name = :"test_log_trim_#{System.unique_integer([:positive])}"
+    id = "test_log_trim_#{System.unique_integer([:positive])}"
+    path = Path.join(tmp_dir, "log_segments")
+    object_storage = ObjectStorage.backend(LocalFilesystem, root: Path.join(tmp_dir, "object_storage"))
+
+    File.mkdir_p!(path)
+
+    server_opts = [
+      cluster: Cluster,
+      otp_name: otp_name,
+      id: id,
+      foreman: self(),
+      path: path,
+      object_storage: object_storage,
+      start_unlocked: true
+    ]
+
+    {:ok, path: path, server_opts: server_opts}
+  end
+
+  describe "durable_up_to on pull" do
+    setup %{server_opts: opts} do
+      {:ok, server: setup_server(opts)}
+    end
+
+    test "advances the trim point and is reflected in facts", %{server: pid} do
+      push_transactions(pid, 1..3)
+      v2 = Version.from_integer(2)
+
+      # First pull catches up without reporting; the follow-up pull reports
+      # that everything at or below v2 is durable downstream.
+      assert {:ok, transactions} = GenServer.call(pid, {:pull, Version.zero(), [limit: 10]})
+      assert length(transactions) == 3
+
+      assert {:ok, [_tx3]} = GenServer.call(pid, {:pull, v2, [limit: 10, durable_up_to: v2]})
+
+      assert :sys.get_state(pid).min_durable_version == v2
+
+      assert {:ok, %{minimum_durable_version: ^v2}} =
+               GenServer.call(pid, {:info, [:minimum_durable_version]})
+    end
+
+    test "is monotonic: an older report never regresses the trim point", %{server: pid} do
+      push_transactions(pid, 1..3)
+      v1 = Version.from_integer(1)
+      v2 = Version.from_integer(2)
+
+      assert {:ok, _} = GenServer.call(pid, {:pull, v2, [durable_up_to: v2]})
+      assert {:ok, _} = GenServer.call(pid, {:pull, v2, [durable_up_to: v1]})
+
+      assert :sys.get_state(pid).min_durable_version == v2
+    end
+
+    test "a pull without durable_up_to leaves the trim point untouched", %{server: pid} do
+      push_transactions(pid, 1..3)
+      v2 = Version.from_integer(2)
+
+      assert {:ok, _} = GenServer.call(pid, {:pull, v2, [durable_up_to: v2]})
+      assert {:ok, _} = GenServer.call(pid, {:pull, v2, []})
+
+      assert :sys.get_state(pid).min_durable_version == v2
+    end
+
+    test "cooperates with the Demux {:min_durable_version, _} report path", %{server: pid} do
+      push_transactions(pid, 1..3)
+      v1 = Version.from_integer(1)
+      v2 = Version.from_integer(2)
+
+      assert {:ok, _} = GenServer.call(pid, {:pull, v2, [durable_up_to: v2]})
+
+      # An older out-of-band report must not regress the pull-reported point.
+      send(pid, {:min_durable_version, v1})
+      :pong = GenServer.call(pid, :ping)
+      assert :sys.get_state(pid).min_durable_version == v2
+    end
+  end
+
+  describe "automatic segment trimming" do
+    setup %{server_opts: opts, path: path} do
+      server = setup_server(opts)
+      segments = install_segments(server, path)
+      {:ok, server: server, segments: segments}
+    end
+
+    test "segments entirely below the trim point are returned to the recycler", %{
+      server: pid,
+      segments: %{v20: v20, v30: v30, seg10_path: seg10_path, seg20_path: seg20_path, tx30: tx30}
+    } do
+      assert {:ok, [^tx30]} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+
+      state = :sys.get_state(pid)
+      assert state.min_durable_version == v20
+      assert Enum.map(state.segments, & &1.min_version) == [v20]
+      assert state.oldest_version == v20
+      assert state.active_segment.min_version == v30
+
+      refute File.exists?(seg10_path)
+      assert File.exists?(seg20_path)
+    end
+
+    test "the segment containing the trim point itself is never trimmed", %{
+      server: pid,
+      segments: %{v10: v10, v20: v20, seg10_path: seg10_path, seg20_path: seg20_path}
+    } do
+      # Everything <= v10 is durable; the segment whose last transaction is
+      # exactly v10 must be retained so pull(start_after: v10) stays servable.
+      assert {:ok, _} = GenServer.call(pid, {:pull, v10, [limit: 10, durable_up_to: v10]})
+
+      state = :sys.get_state(pid)
+      assert Enum.map(state.segments, & &1.min_version) == [v20, v10]
+      assert state.oldest_version == v10
+      assert File.exists?(seg10_path)
+      assert File.exists?(seg20_path)
+    end
+
+    test "the active write segment is never recycled", %{
+      server: pid,
+      segments: %{v30: v30, seg10_path: seg10_path, seg20_path: seg20_path, seg30_path: seg30_path}
+    } do
+      v100 = Version.from_integer(100)
+
+      # No transactions exist after v100, and no willing_to_wait_in_ms was
+      # given, so the pull itself is refused - but the durability report and
+      # the trimming it drives still apply.
+      assert {:error, :version_too_new} =
+               GenServer.call(pid, {:pull, v100, [limit: 10, durable_up_to: v100]})
+
+      state = :sys.get_state(pid)
+      assert state.min_durable_version == v100
+      assert state.segments == []
+      assert state.active_segment.min_version == v30
+      assert state.oldest_version == v30
+
+      refute File.exists?(seg10_path)
+      refute File.exists?(seg20_path)
+      assert File.exists?(seg30_path)
+    end
+
+    test "a pull for trimmed history returns :version_too_old", %{
+      server: pid,
+      segments: %{v10: v10, v20: v20}
+    } do
+      assert {:ok, _} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+
+      assert {:error, :version_too_old} = GenServer.call(pid, {:pull, v10, [limit: 10]})
+      assert {:error, :version_too_old} = GenServer.call(pid, {:pull, Version.zero(), [limit: 10]})
+    end
+
+    test "a pull at exactly the trim point still succeeds after trimming", %{
+      server: pid,
+      segments: %{v20: v20, tx30: tx30}
+    } do
+      assert {:ok, _} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+      assert {:ok, [^tx30]} = GenServer.call(pid, {:pull, v20, [limit: 10]})
+    end
+
+    test "trimming emits telemetry with the segment count and new trim point", %{
+      server: pid,
+      segments: %{v20: v20}
+    } do
+      handler_id = "trim-telemetry-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:bedrock, :log, :segments_trimmed],
+        fn event, measurements, metadata, _ -> send(test_pid, {:trim_event, event, measurements, metadata}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:ok, _} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+
+      assert_receive {:trim_event, [:bedrock, :log, :segments_trimmed], %{segments_trimmed: 1}, %{trim_point: ^v20}}
+
+      # A repeated report at the same trim point trims nothing and emits nothing.
+      assert {:ok, _} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+      refute_receive {:trim_event, _, _, _}
+    end
+
+    test "recovery still works after trimming", %{
+      server: pid,
+      segments: %{v20: v20, v30: v30}
+    } do
+      assert {:ok, _} = GenServer.call(pid, {:pull, v20, [limit: 10, durable_up_to: v20]})
+
+      assert {:ok, ^pid, info} = GenServer.call(pid, {:lock_for_recovery, 1})
+
+      assert %{
+               kind: :log,
+               oldest_version: ^v20,
+               last_version: ^v30,
+               minimum_durable_version: ^v20
+             } = info
+
+      assert {:ok, ^pid} = GenServer.call(pid, {:recover_from, [], v30, v30})
+
+      # The recovered log accepts new pushes and serves them to pulls.
+      tx31 = TransactionTestSupport.new_log_transaction(31, %{"k31" => "v31"})
+      assert :ok = GenServer.call(pid, {:push, tx31, v30})
+      assert {:ok, [^tx31]} = GenServer.call(pid, {:pull, v30, [limit: 10]})
+    end
+  end
+
+  # Installs a realistic three-segment layout into the running server:
+  #
+  #   seg10 (inactive):  tx10            - fully below any trim point >= v20
+  #   seg20 (inactive):  tx20            - contains version 20
+  #   seg30 (active):    tx30            - the active write segment
+  #
+  # Segment files are real WAL files written via Writer so that recovery and
+  # the segment recycler can operate on them.
+  defp install_segments(pid, path) do
+    v10 = Version.from_integer(10)
+    v20 = Version.from_integer(20)
+    v30 = Version.from_integer(30)
+
+    tx10 = TransactionTestSupport.new_log_transaction(10, %{"k10" => "v10"})
+    tx20 = TransactionTestSupport.new_log_transaction(20, %{"k20" => "v20"})
+    tx30 = TransactionTestSupport.new_log_transaction(30, %{"k30" => "v30"})
+
+    seg10_path = Path.join(path, Segment.encode_file_name(10))
+    seg20_path = Path.join(path, Segment.encode_file_name(20))
+    seg30_path = Path.join(path, Segment.encode_file_name(30))
+
+    write_segment_file!(seg10_path, [{tx10, v10}])
+    write_segment_file!(seg20_path, [{tx20, v20}])
+    write_segment_file!(seg30_path, [{tx30, v30}])
+
+    :sys.replace_state(pid, fn state ->
+      %{
+        state
+        | active_segment: %Segment{path: seg30_path, min_version: v30, transactions: [tx30]},
+          segments: [
+            %Segment{path: seg20_path, min_version: v20, transactions: [tx20]},
+            %Segment{path: seg10_path, min_version: v10, transactions: [tx10]}
+          ],
+          oldest_version: v10,
+          last_version: v30,
+          min_durable_version: nil
+      }
+    end)
+
+    %{
+      v10: v10,
+      v20: v20,
+      v30: v30,
+      tx10: tx10,
+      tx20: tx20,
+      tx30: tx30,
+      seg10_path: seg10_path,
+      seg20_path: seg20_path,
+      seg30_path: seg30_path
+    }
+  end
+
+  defp write_segment_file!(path, transactions_with_versions) do
+    File.write!(path, :binary.copy(<<0>>, 65_536))
+    {:ok, writer} = Writer.open(path)
+
+    writer =
+      Enum.reduce(transactions_with_versions, writer, fn {transaction, version}, writer ->
+        {:ok, writer} = Writer.append(writer, transaction, version)
+        writer
+      end)
+
+    :ok = Writer.close(writer)
+  end
+
+  defp push_transactions(pid, versions) do
+    Enum.each(versions, fn i ->
+      transaction = TransactionTestSupport.new_log_transaction(i, %{"k#{i}" => "v#{i}"})
+      expected_version = Version.from_integer(i - 1)
+      :ok = GenServer.call(pid, {:push, transaction, expected_version})
+    end)
+  end
+
+  defp setup_server(opts) do
+    pid = start_supervised!(Server.child_spec(opts))
+
+    eventually(fn ->
+      state = :sys.get_state(pid)
+      assert state.segment_recycler
+    end)
+
+    pid
+  end
+
+  defp eventually(assertion_fn, timeout \\ 1000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    eventually_loop(assertion_fn, deadline)
+  end
+
+  defp eventually_loop(assertion_fn, deadline) do
+    assertion_fn.()
+  rescue
+    _ ->
+      if System.monotonic_time(:millisecond) < deadline do
+        eventually_loop(assertion_fn, deadline)
+      else
+        assertion_fn.()
+      end
+  end
+end


### PR DESCRIPTION
## Why

A Bedrock log is short-term memory: it holds transactions on disk in segment files until the data is safely stored downstream. But nothing ever told the log "this data is safe elsewhere, you can let go" as part of normal pulling — so outside of recovery, segments piled up forever.

Worse, the cleanup path that *did* exist (the Demux's out-of-band `{:min_durable_version, v}` message) had a live off-by-one: it deleted the segment whose last transaction was exactly `v`. The consumer that just said "I'm safe up to v" naturally asks next for "everything after v" — and could be told `:version_too_old`, locked out of data that still existed on disk. This PR fixes that live bug.

## What

Two things:

1. **Inline progress reports.** `Log.pull/3` gains a `durable_up_to` option, so a consumer can say "everything at or below this version is durable downstream" in the same call it uses to fetch more data. The log keeps one trim point per log — the monotonic maximum of all reports; stale reports never move it backward.
2. **Automatic cleanup.** When the trim point advances, any inactive segment whose contents are entirely *strictly below* it is returned to the recycler. The segment containing the trim point, and the active write segment, always survive.

The inline option is inert today — materializers deliberately don't report (several pull from one log, and a shared max could trim history a slower one still needs). The Demux becomes the inline reporter when it takes over pulling in bedrock-q67.10; its out-of-band path feeds the same logic meanwhile.

## How

Take a log with segments **A** [v1–v10], **B** [v11–v20], and active **C** [v21–v30]:

| Report `durable_up_to` | A | B | C | Next pull |
|---|---|---|---|---|
| 10 | kept (last = 10, not < 10) | kept | kept | `pull(10)` → v11… |
| 15 | trimmed (10 < 15) | kept (20 ≮ 15) | kept | `pull(15)` → v16… |
| 20 | trimmed | **kept** (20 ≮ 20) | kept | `pull(20)` → v21… |
| 31 | trimmed | trimmed (20 < 31) | kept (active, exempt) | `pull(31)` waits for new data |

The "strictly below" boundary is the row for 20: with the old `<=`, B would be deleted too, `oldest_version` would jump to 21, and `pull(20)` — the reporter's very next request — would fail `:version_too_old` even though v21–v30 were still on disk. With `<`, the boundary segment is retained and the pull succeeds.

Trims emit `[:bedrock, :log, :segments_trimmed]` telemetry; the dead `subscriber` pull option (declared but ignored) is removed. 11 new tests hand-trace exactly these scenarios (`trimming_test.exs`); full suite, credo, dialyzer clean.

Closes bedrock-q67.8.
