### PR TITLE
Fix three flaky tests: telemetry handler races, forgetful fake storage, and a 1ms-timeout crash (bedrock-c4u, bedrock-y6e)

### DIFF
--- a/test/bedrock/control_plane/director/recovery/tracing_test.exs
+++ b/test/bedrock/control_plane/director/recovery/tracing_test.exs
@@ -1,5 +1,8 @@
 defmodule Bedrock.ControlPlane.Director.Recovery.TracingTest do
-  use ExUnit.Case, async: true
+  # Attaches/detaches a globally-named telemetry handler; concurrent async
+  # tests emitting matching events can crash the handler (telemetry then
+  # auto-detaches it), so this module is not async-safe.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/test/bedrock/data_plane/commit_proxy/tracing_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/tracing_test.exs
@@ -1,5 +1,8 @@
 defmodule Bedrock.DataPlane.CommitProxy.TracingTest do
-  use ExUnit.Case, async: true
+  # Attaches/detaches a globally-named telemetry handler; concurrent async
+  # tests emitting matching events can crash the handler (telemetry then
+  # auto-detaches it), so this module is not async-safe.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/test/bedrock/data_plane/log/tracing_test.exs
+++ b/test/bedrock/data_plane/log/tracing_test.exs
@@ -1,5 +1,12 @@
 defmodule Bedrock.DataPlane.Log.TracingTest do
-  use ExUnit.Case, async: true
+  # This module attaches/detaches a globally-named telemetry handler
+  # ("bedrock_trace_data_plane_log"). While attached, any concurrently-running
+  # async test that emits [:bedrock, :log, *] telemetry (e.g. Shale log server
+  # tests) invokes the handler in a process without the expected Logger
+  # metadata; the handler raises and :telemetry auto-detaches it, making
+  # stop/0 return {:error, :not_found} mid-test. Global mutable state means
+  # this module cannot safely run async.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -666,8 +666,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       {:ok, pid} = start_supervised(child_spec)
       wait_for_health_report(worker_id, pid)
 
-      # Test timeout scenarios - should either succeed or timeout gracefully
-      result = GenServer.call(pid, {:info, :kind}, 1)
+      # Test timeout scenarios - should either succeed or timeout gracefully.
+      # A 1ms timeout EXITS the caller rather than returning a value, so the
+      # call must be wrapped; under full-suite load this exit is routine.
+      result =
+        try do
+          GenServer.call(pid, {:info, :kind}, 1)
+        catch
+          :exit, {:timeout, _} -> :timed_out
+        end
 
       case result do
         {:ok, :materializer} -> :ok

--- a/test/bedrock/data_plane/materializer/olivine/tracing_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/tracing_test.exs
@@ -1,5 +1,8 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.TracingTest do
-  use ExUnit.Case, async: true
+  # Attaches/detaches a globally-named telemetry handler; concurrent async
+  # tests emitting matching events can crash the handler (telemetry then
+  # auto-detaches it), so this module is not async-safe.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/test/bedrock/directory/property_test.exs
+++ b/test/bedrock/directory/property_test.exs
@@ -100,82 +100,100 @@ defmodule Bedrock.Directory.PropertyTest do
 
   property "directory prefixes are unique within same layer" do
     check all(paths <- uniq_list_of(valid_directory_path(), min_length: 1, max_length: 3)) do
-      # Sort paths by depth to ensure parents created before children
-      sorted_paths = Enum.sort_by(paths, &length/1)
+      assert_unique_prefixes(paths)
+    end
+  end
 
-      # Track which directories will be successfully created
-      # Root always exists with the new API, so start with it in the set
-      created_dirs =
-        Enum.reduce(sorted_paths, MapSet.new([[]]), fn path, acc ->
-          parent_path = Enum.drop(path, -1)
+  # Regression for bedrock-y6e: when the generated paths include both a parent
+  # and its child, the old :get stub's "key in sorted_paths -> nil" clause
+  # shadowed the created-directories clause, so creating the child failed with
+  # :parent_directory_does_not_exist even though the parent had just been
+  # created. The stub is now stateful (records puts), which this exercises
+  # deterministically.
+  test "regression: creating a child after its parent succeeds" do
+    assert_unique_prefixes([["Q"], ["Q", "G"]])
+  end
 
-          if path == [] or MapSet.member?(acc, parent_path) do
-            MapSet.put(acc, path)
-          else
-            acc
-          end
-        end)
+  defp assert_unique_prefixes(paths) do
+    # Sort paths by depth to ensure parents created before children
+    sorted_paths = Enum.sort_by(paths, &length/1)
 
-      # Prefix counter for deterministic allocation
-      prefix_counter = :counters.new(1, [])
+    # Oracle: which directories SHOULD be successfully created.
+    # Root always exists with the new API, so start with it in the set.
+    created_dirs =
+      Enum.reduce(sorted_paths, MapSet.new([[]]), fn path, acc ->
+        parent_path = Enum.drop(path, -1)
 
-      next_prefix_fn = fn ->
-        n = :counters.get(prefix_counter, 1)
-        :counters.add(prefix_counter, 1, 1)
-        <<n::32>>
-      end
-
-      # Use keyspace-aware stubs
-      stub(MockRepo, :get, fn _keyspace, key ->
-        cond do
-          # Version not initialized
-          key == ["version"] -> nil
-          # Directory doesn't exist yet
-          key in sorted_paths -> nil
-          # Root directory always exists
-          key == [] -> {<<>>, ""}
-          # Parent exists
-          MapSet.member?(created_dirs, key) -> {<<0, 1>>, ""}
-          true -> nil
+        if path == [] or MapSet.member?(acc, parent_path) do
+          MapSet.put(acc, path)
+        else
+          acc
         end
       end)
 
-      stub(MockRepo, :put, fn %Keyspace{}, _key, _value -> :ok end)
+    # Prefix counter for deterministic allocation
+    prefix_counter = :counters.new(1, [])
 
-      layer = Directory.root(MockRepo, next_prefix_fn: next_prefix_fn)
-
-      # Create all directories and verify unique prefixes
-      {successful_nodes, all_prefixes} =
-        Enum.reduce(sorted_paths, {[], []}, fn path, {nodes, prefixes} ->
-          should_succeed = MapSet.member?(created_dirs, path)
-
-          case Directory.create(layer, path) do
-            {:ok, node} when should_succeed ->
-              refute node.prefix in prefixes,
-                     "Duplicate prefix #{inspect(node.prefix)} for path #{inspect(path)}"
-
-              {[node | nodes], [node.prefix | prefixes]}
-
-            {:error, :parent_directory_does_not_exist} when not should_succeed ->
-              {nodes, prefixes}
-
-            {:ok, _} when not should_succeed ->
-              flunk("Created #{inspect(path)} but parent doesn't exist")
-
-            {:error, reason} when should_succeed ->
-              flunk("Failed to create #{inspect(path)}: #{inspect(reason)}")
-
-            {:error, reason} ->
-              flunk("Unexpected error for #{inspect(path)}: #{inspect(reason)}")
-          end
-        end)
-
-      # Verify all successfully created nodes have unique prefixes
-      assert length(all_prefixes) == length(Enum.uniq(all_prefixes))
-      # Only count non-root paths since root already exists
-      expected_creations = created_dirs |> MapSet.delete([]) |> MapSet.size()
-      assert length(successful_nodes) == expected_creations
+    next_prefix_fn = fn ->
+      n = :counters.get(prefix_counter, 1)
+      :counters.add(prefix_counter, 1, 1)
+      <<n::32>>
     end
+
+    # Stateful store backing the stubs: :put records what was written so
+    # that :get reflects directories created earlier in this run. Seeded
+    # with the root, which always exists.
+    {:ok, store} = Agent.start_link(fn -> %{[] => {<<>>, ""}} end)
+
+    stub(MockRepo, :get, fn _keyspace, key ->
+      # Version not initialized
+      if key == ["version"] do
+        nil
+      else
+        # Everything else comes from the recorded state (nil if never put)
+        Agent.get(store, &Map.get(&1, key))
+      end
+    end)
+
+    stub(MockRepo, :put, fn %Keyspace{}, key, value ->
+      Agent.update(store, &Map.put(&1, key, value))
+      :ok
+    end)
+
+    layer = Directory.root(MockRepo, next_prefix_fn: next_prefix_fn)
+
+    # Create all directories and verify unique prefixes
+    {successful_nodes, all_prefixes} =
+      Enum.reduce(sorted_paths, {[], []}, fn path, {nodes, prefixes} ->
+        should_succeed = MapSet.member?(created_dirs, path)
+
+        case Directory.create(layer, path) do
+          {:ok, node} when should_succeed ->
+            refute node.prefix in prefixes,
+                   "Duplicate prefix #{inspect(node.prefix)} for path #{inspect(path)}"
+
+            {[node | nodes], [node.prefix | prefixes]}
+
+          {:error, :parent_directory_does_not_exist} when not should_succeed ->
+            {nodes, prefixes}
+
+          {:ok, _} when not should_succeed ->
+            flunk("Created #{inspect(path)} but parent doesn't exist")
+
+          {:error, reason} when should_succeed ->
+            flunk("Failed to create #{inspect(path)}: #{inspect(reason)}")
+
+          {:error, reason} ->
+            flunk("Unexpected error for #{inspect(path)}: #{inspect(reason)}")
+        end
+      end)
+
+    # Verify all successfully created nodes have unique prefixes
+    assert length(all_prefixes) == length(Enum.uniq(all_prefixes))
+    # Only count non-root paths since root already exists
+    expected_creations = created_dirs |> MapSet.delete([]) |> MapSet.size()
+    assert length(successful_nodes) == expected_creations
+    Agent.stop(store)
   end
 
   property "directory operations preserve metadata" do


### PR DESCRIPTION
This PR fixes **three** flaky tests that failed CI runs at random and wasted everyone's time re-running suites. None of them were real bugs in Bedrock — each was a hidden race or trap in the test itself.

## 1. Tracing tests randomly lost their telemetry handler (bedrock-c4u)

**Why:** The four tracing test modules attach a telemetry handler with a fixed, global name, then detach it at the end. They ran `async: true`, so other tests ran at the same time. The telemetry library has a surprising rule: if a handler crashes while handling an event, it silently **uninstalls** that handler.

**What happened, step by step:**
1. A tracing test attaches the global handler.
2. Some unrelated concurrent test emits a matching event (e.g. `[:bedrock, :log, ...]`).
3. Our handler runs in that other test's process, where the Logger metadata it expects is missing — it crashes.
4. Telemetry quietly detaches the crashed handler.
5. The tracing test later calls `stop/0` to detach it, finds nothing, and fails with `{:error, :not_found}`.

**Fix:** These modules mutate global state, so they now run `async: false`, with comments explaining why.

## 2. Directory property test's fake storage forgot what it created (bedrock-y6e)

**Why:** The prefix-uniqueness property test used a stateless fake storage: any path in the to-create list answered "doesn't exist" — **even after it was created**. So when the generator happened to produce both a parent and its child (say `["Q"]` then `["Q", "G"]`), creating `["Q"]` succeeded, but creating `["Q", "G"]` asked "does `["Q"]` exist?", got "no", and failed with `:parent_directory_does_not_exist`. Rare sample, rare failure.

**Fix:** The fake storage is now a real (tiny) store: `put` records writes in an Agent, and `get` reads them back, so a just-created parent actually exists. A deterministic regression test pins the exact `["Q"]`, `["Q", "G"]` case.

## 3. The olivine 1ms-timeout ghost

**Why:** An olivine integration test called `GenServer.call(pid, {:info, :kind}, 1)` — a 1-millisecond deadline. When a `GenServer.call` times out, it doesn't return an error value; it **throws** (exits the caller). Under full-suite load, 1ms always expires, so the whole test process blew up. This was the unattributable single-run failure we'd seen roughly 4 times.

**Fix:** Wrap the call so a timeout becomes a value instead of a crash:

```elixir
try do
  GenServer.call(pid, {:info, :kind}, 1)
catch
  :exit, {:timeout, _} -> :timed_out
end
```

Closes bedrock-c4u, bedrock-y6e.
