### PR TITLE
Reconcile death healing with coverage sweep (bedrock-q67.7)

### DIFF
--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -49,6 +49,15 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder do
   def notify_covered(placeholder, tag, materializer), do: cast(placeholder, {:covered, tag, materializer})
 
   @doc """
+  Notifies the placeholder that a shard tag's materializer has died and
+  the tag is uncovered again. The tag's `covered` entry (and demand
+  dedupe) is cleared so subsequent requests park and re-demand coverage
+  instead of being forwarded to the dead pid.
+  """
+  @spec notify_uncovered(ref(), Bedrock.range_tag()) :: :ok
+  def notify_uncovered(placeholder, tag), do: cast(placeholder, {:uncovered, tag})
+
+  @doc """
   Notifies the placeholder that recruitment for a shard tag has failed.
   Parked requests for the tag are shed with `{:error, :unavailable}` and
   the demand dedupe is cleared so a later request re-triggers recruitment.

--- a/lib/bedrock/control_plane/distributor/placeholder/server.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/server.ex
@@ -109,6 +109,9 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder.Server do
     t |> reschedule_expiry() |> noreply()
   end
 
+  def handle_cast({:uncovered, tag}, %State{} = t),
+    do: noreply(%{t | covered: Map.delete(t.covered, tag), demanded: MapSet.delete(t.demanded, tag)})
+
   def handle_cast({:coverage_failed, tag, reason}, %State{} = t) do
     {waiting, entries} = WaitingList.remove_all(t.waiting, tag)
     WaitingList.reply_to_expired(entries, {:error, :unavailable})

--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -13,7 +13,8 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   the shard's logs so it starts pulling immediately.
 
   The Foreman/Materializer calls are injectable through the context map
-  (`:create_worker_fn`, `:lock_materializer_fn`, `:unlock_materializer_fn`)
+  (`:create_worker_fn`, `:lock_materializer_fn`, `:unlock_materializer_fn`,
+  `:remove_worker_fn`)
   using the same seam conventions as the bootstrap phase, so tests can stub
   the worker layer without reimplementing the plumbing.
   """
@@ -22,6 +23,8 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
+
+  require Logger
 
   @type create_worker_fn ::
           (foreman :: {atom(), node()}, Worker.id(), :materializer, keyword() ->
@@ -32,6 +35,8 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   @type unlock_materializer_fn ::
           (pid(), Bedrock.version(), TransactionSystemLayout.t() ->
              :ok | {:error, term()} | {:failure, term(), term()})
+  @type remove_worker_fn ::
+          (foreman :: {atom(), node()}, Worker.id(), keyword() -> :ok | {:error, term()})
 
   @type context :: %{
           required(:cluster) => module(),
@@ -41,22 +46,61 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
           required(:node_capabilities) => %{Bedrock.Cluster.capability() => [node()]},
           optional(:create_worker_fn) => create_worker_fn(),
           optional(:lock_materializer_fn) => lock_materializer_fn(),
-          optional(:unlock_materializer_fn) => unlock_materializer_fn()
+          optional(:unlock_materializer_fn) => unlock_materializer_fn(),
+          optional(:remove_worker_fn) => remove_worker_fn()
         }
 
   @doc """
   Recruits a materializer for the given shard tag: node selection, worker
   creation via the node's Foreman, epoch lock, and unlock with the shard's
-  logs. Returns the live materializer pid and the node it was placed on.
+  logs. Returns the live materializer pid, the node it was placed on, and
+  the worker id it was created under (so the caller can remove the worker
+  if fencing the recruit into the layout fails).
+
+  A worker that was created but never reached service (lock or unlock
+  failed) is removed again via `remove_orphaned_worker/3` before the error
+  is returned, so failed recruitment does not leak idle or half-locked
+  workers on the node.
   """
-  @spec recruit(Bedrock.range_tag(), context()) :: {:ok, pid(), node()} | {:error, term()}
+  @spec recruit(Bedrock.range_tag(), context()) ::
+          {:ok, pid(), node(), Worker.id()} | {:error, term()}
   def recruit(tag, context) do
     with {:ok, node} <- find_materializer_capable_node(context.node_capabilities),
-         {:ok, worker_ref} <- create_materializer_worker(node, tag, context),
-         {:ok, pid, recovery_info} <- lock_materializer({worker_ref, node}, node, context),
-         :ok <- unlock_and_start_pulling(pid, tag, node, recovery_info, context) do
-      {:ok, pid, node}
+         {:ok, worker_ref, worker_id} <- create_materializer_worker(node, tag, context) do
+      with {:ok, pid, recovery_info} <- lock_materializer({worker_ref, node}, node, context),
+           :ok <- unlock_and_start_pulling(pid, tag, node, recovery_info, context) do
+        {:ok, pid, node, worker_id}
+      else
+        {:error, _reason} = error ->
+          remove_orphaned_worker(worker_id, node, context)
+          error
+      end
     end
+  end
+
+  @doc """
+  Best-effort removal of a worker left behind by a failed recruitment. The
+  worker never carried data a client could reach, so removal is safe; any
+  failure to remove it (foreman unreachable, worker already gone) is
+  logged and swallowed - orphan cleanup must never mask the original
+  recruitment error.
+  """
+  @spec remove_orphaned_worker(Worker.id(), node(), context()) :: :ok
+  def remove_orphaned_worker(worker_id, node, context) do
+    remove_worker_fn = Map.get(context, :remove_worker_fn, &Foreman.remove_worker/3)
+    foreman_ref = {context.cluster.otp_name(:foreman), node}
+
+    try do
+      remove_worker_fn.(foreman_ref, worker_id, timeout: 5_000)
+    catch
+      kind, reason ->
+        Logger.warning(
+          "Failed to remove orphaned materializer worker #{inspect(worker_id)} " <>
+            "on #{inspect(node)}: #{inspect({kind, reason})}"
+        )
+    end
+
+    :ok
   end
 
   # Placement: same convention as the recovery bootstrap phase - the first
@@ -74,7 +118,7 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
     create_worker_fn = Map.get(context, :create_worker_fn, &Foreman.new_worker/4)
 
     case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000) do
-      {:ok, worker_ref} -> {:ok, worker_ref}
+      {:ok, worker_ref} -> {:ok, worker_ref, worker_id}
       {:error, reason} -> {:error, {:worker_creation_failed, reason, tag, node}}
     end
   end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -289,6 +289,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   @spec maybe_recruit(State.t(), Bedrock.range_tag()) :: State.t()
   defp maybe_recruit(%State{} = t, tag) do
     cond do
+      match?({:ok, _}, covered_materializer(t, tag)) ->
+        # Already covered by a live monitored materializer: a demand-raced
+        # recruitment completed while a placeholder swap was in flight.
+        # Recruiting again would orphan the live recruit.
+        t
+
       MapSet.member?(t.pending_demands, tag) ->
         # A recruitment for this tag is already in flight.
         t

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -7,9 +7,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   stops (`:normal`) when the director exits or when a newer epoch is
   signaled - the next director recruits a fresh distributor.
 
-  This is the Phase A skeleton: coverage tracking, recruitment, and
-  placeholder supervision arrive in later tickets and will all pass
-  through the epoch guard implemented here.
+  Owns Phase A coverage policy: placeholder supervision, on-demand
+  materializer recruitment, and materializer-death healing (monitor the
+  shard's materializers; on death swap the placeholder into the TSL slot
+  and re-recruit). Every shard-map mutation passes through the epoch
+  guard implemented here.
   """
 
   use GenServer
@@ -21,11 +23,15 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       emit_coverage_demand: 2,
       emit_recruitment_started: 3,
       emit_recruitment_succeeded: 5,
-      emit_recruitment_failed: 5
+      emit_recruitment_failed: 5,
+      emit_materializer_down: 4,
+      emit_healing_started: 3,
+      emit_healing_completed: 3
     ]
 
   import Bedrock.Internal.GenServer.Replies
 
+  alias Bedrock.ControlPlane.Config.RecoveryAttempt
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Director
   alias Bedrock.ControlPlane.Distributor.Placeholder
@@ -89,7 +95,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
     emit_distributor_started(state.cluster, state.epoch, state.director)
 
-    {:ok, start_placeholder(state)}
+    {:ok, state |> start_placeholder() |> monitor_existing_materializers()}
   end
 
   @impl true
@@ -131,14 +137,24 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   # Coverage demand from the placeholder: recruit a materializer for the
   # shard unless a recruitment is already in flight or the tag is inside
-  # its failure-backoff window.
+  # its failure-backoff window. A tag we already cover with a monitored,
+  # live materializer is re-delivered instead of re-recruited: a restarted
+  # placeholder loses its `covered` map, and the `notify_covered` for a
+  # completed recruitment may have been cast to the dead placeholder pid.
   def handle_cast({:coverage_demand, tag}, %State{} = t) do
     Logger.info("Distributor for epoch #{t.epoch} received coverage demand for shard tag #{inspect(tag)}")
     emit_coverage_demand(t.cluster, tag)
 
-    t
-    |> maybe_recruit(tag)
-    |> noreply()
+    case covered_materializer(t, tag) do
+      {:ok, materializer} ->
+        if t.placeholder, do: Placeholder.notify_covered(t.placeholder, tag, materializer)
+        noreply(t)
+
+      :error ->
+        t
+        |> maybe_recruit(tag)
+        |> noreply()
+    end
   end
 
   # Completion of an asynchronous recruitment attempt (cast back to
@@ -147,7 +163,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     emit_recruitment_succeeded(t.cluster, t.epoch, tag, node, duration_us)
     if t.placeholder, do: Placeholder.notify_covered(t.placeholder, tag, materializer)
 
-    noreply(%{t | pending_demands: MapSet.delete(t.pending_demands, tag)})
+    t
+    |> monitor_materializer(tag, materializer)
+    |> complete_healing(tag)
+    |> Map.update!(:pending_demands, &MapSet.delete(&1, tag))
+    |> noreply()
   end
 
   def handle_cast({:recruitment_complete, tag, {:error, :newer_epoch_exists}, _duration_us}, %State{} = t) do
@@ -177,6 +197,39 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     noreply(%{t | pending_demands: MapSet.delete(t.pending_demands, tag)})
   end
 
+  # Outcome of the placeholder swap a materializer death triggered. On
+  # success, re-recruit eagerly: the shard demonstrably had traffic (it was
+  # materialized), so healing should not wait for the next read; the
+  # per-tag failure backoff in `maybe_recruit/2` still applies. Chaining
+  # the recruitment after the swap also guarantees the recruitment's TSL
+  # delta lands after the placeholder's.
+  def handle_cast({:placeholder_swap_complete, tag, :ok}, %State{} = t) do
+    t
+    |> maybe_recruit(tag)
+    |> noreply()
+  end
+
+  def handle_cast({:placeholder_swap_complete, tag, {:error, :newer_epoch_exists}}, %State{} = t) do
+    Logger.info(
+      "Distributor for epoch #{t.epoch} superseded (placeholder swap for shard tag #{inspect(tag)} rejected); stopping"
+    )
+
+    stop(t, :normal)
+  end
+
+  def handle_cast({:placeholder_swap_complete, tag, error}, %State{} = t) do
+    Logger.warning(
+      "Distributor for epoch #{t.epoch} failed to swap the placeholder into shard tag " <>
+        "#{inspect(tag)}: #{inspect(error)}"
+    )
+
+    # Recruit anyway: a successful recruitment writes its own TSL delta,
+    # which heals the slot without the intermediate placeholder hop.
+    t
+    |> maybe_recruit(tag)
+    |> noreply()
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, director, reason}, %State{director: director} = t) do
     Logger.info("Distributor for epoch #{t.epoch} stopping: director exited (#{inspect(reason)})")
@@ -184,10 +237,36 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     stop(t, :normal)
   end
 
+  # A monitored materializer died: heal the shard. The placeholder is told
+  # the tag is uncovered (so requests park and re-demand instead of being
+  # forwarded to the corpse), the placeholder pid is swapped into the TSL
+  # slot, and - once the swap completes - the tag is eagerly re-recruited.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %State{} = t) when is_map_key(t.materializer_monitors, ref) do
+    {{tag, _pid}, monitors} = Map.pop(t.materializer_monitors, ref)
+
+    Logger.warning(
+      "Distributor for epoch #{t.epoch} healing shard tag #{inspect(tag)}: materializer exited (#{inspect(reason)})"
+    )
+
+    if t.placeholder, do: Placeholder.notify_uncovered(t.placeholder, tag)
+    emit_materializer_down(t.cluster, t.epoch, tag, reason)
+    emit_healing_started(t.cluster, t.epoch, tag)
+    swap_placeholder_into_slot(t, tag)
+
+    noreply(%{t | materializer_monitors: monitors, healing: MapSet.put(t.healing, tag)})
+  end
+
   def handle_info({:EXIT, placeholder, reason}, %State{placeholder: placeholder} = t) do
     Logger.warning("Distributor for epoch #{t.epoch} restarting placeholder (exited: #{inspect(reason)})")
 
-    noreply(start_placeholder(t))
+    t = start_placeholder(t)
+
+    # Slots healed onto the dead placeholder hold a dead pid until
+    # re-recruitment lands its delta; re-point them at the restarted
+    # placeholder so stale-layout clients keep landing somewhere that parks.
+    Enum.each(t.healing, &swap_placeholder_into_slot(t, &1))
+
+    noreply(t)
   end
 
   def handle_info(message, %State{} = t) do
@@ -217,6 +296,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       in_backoff?(t, tag) ->
         Logger.debug("Distributor for epoch #{t.epoch} ignoring demand for shard tag #{inspect(tag)} (in backoff)")
 
+        # Shed promptly and clear the placeholder's demand dedupe: parked
+        # readers would otherwise wait out their full budget, and a stuck
+        # `demanded` flag would suppress the re-demand that retries
+        # recruitment once the backoff expires.
+        if t.placeholder, do: Placeholder.notify_coverage_failed(t.placeholder, tag, :backoff)
         t
 
       true ->
@@ -271,9 +355,18 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
         result =
           try do
-            with {:ok, materializer, node} <- Recruitment.recruit(tag, context),
-                 :ok <- Director.apply_tsl_delta(director, %{tag => materializer}, epoch) do
-              {:ok, materializer, node}
+            with {:ok, materializer, node, worker_id} <- Recruitment.recruit(tag, context) do
+              case Director.apply_tsl_delta(director, %{tag => materializer}, epoch) do
+                :ok ->
+                  {:ok, materializer, node}
+
+                error ->
+                  # The recruit is unfenced: no layout slot will ever name
+                  # it, so nothing can read from it or heal it. Remove it
+                  # rather than leak an orphaned worker.
+                  Recruitment.remove_orphaned_worker(worker_id, node, context)
+                  error
+              end
             end
           rescue
             exception -> {:error, {:recruitment_crashed, Exception.message(exception)}}
@@ -320,14 +413,102 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     }
   end
 
+  # Death healing
+
+  # Monitors the materializers the recovery-built TSL snapshot already
+  # names: the director deliberately does not monitor materializers, so
+  # without this the death of a bootstrap-created materializer would go
+  # unhealed. The system shard is excluded - clients route it via the
+  # TSL's `metadata_materializer` field, which a `shard_materializers`
+  # delta cannot heal, so its death is a recovery-level concern.
+  @system_shard RecoveryAttempt.system_shard_id()
+
+  @spec monitor_existing_materializers(State.t()) :: State.t()
+  defp monitor_existing_materializers(%State{} = t) do
+    monitors =
+      t.transaction_system_layout
+      |> Map.get(:shard_materializers, %{})
+      |> Enum.reduce(t.materializer_monitors, fn
+        {tag, pid}, acc when is_pid(pid) and tag != @system_shard ->
+          Map.put(acc, Process.monitor(pid), {tag, pid})
+
+        _other, acc ->
+          acc
+      end)
+
+    %{t | materializer_monitors: monitors}
+  end
+
+  # Monitors a newly recruited materializer, replacing any stale monitor
+  # held for the same tag.
+  @spec monitor_materializer(State.t(), Bedrock.range_tag(), pid()) :: State.t()
+  defp monitor_materializer(%State{} = t, tag, materializer) do
+    {stale, live} =
+      Enum.split_with(t.materializer_monitors, fn {_ref, {monitored_tag, _pid}} -> monitored_tag == tag end)
+
+    Enum.each(stale, fn {ref, _entry} -> Process.demonitor(ref, [:flush]) end)
+
+    monitors = live |> Map.new() |> Map.put(Process.monitor(materializer), {tag, materializer})
+
+    %{t | materializer_monitors: monitors}
+  end
+
+  @spec covered_materializer(State.t(), Bedrock.range_tag()) :: {:ok, pid()} | :error
+  defp covered_materializer(%State{materializer_monitors: monitors}, tag) do
+    Enum.find_value(monitors, :error, fn {_ref, {monitored_tag, pid}} ->
+      if monitored_tag == tag, do: {:ok, pid}
+    end)
+  end
+
+  @spec complete_healing(State.t(), Bedrock.range_tag()) :: State.t()
+  defp complete_healing(%State{} = t, tag) do
+    if MapSet.member?(t.healing, tag) do
+      emit_healing_completed(t.cluster, t.epoch, tag)
+      %{t | healing: MapSet.delete(t.healing, tag)}
+    else
+      t
+    end
+  end
+
+  # Swaps the placeholder pid into a dead materializer's TSL slot so
+  # stale-layout clients park at the placeholder instead of erroring
+  # against a corpse. The delta is epoch-guarded at the director; it runs
+  # off the message loop and the outcome is cast back so a superseded
+  # distributor stops itself and re-recruitment is serialized after the
+  # swap.
+  @spec swap_placeholder_into_slot(State.t(), Bedrock.range_tag()) :: :ok
+  defp swap_placeholder_into_slot(%State{} = t, tag) do
+    distributor = self()
+    director = t.director
+    epoch = t.epoch
+    placeholder = t.placeholder
+
+    {:ok, _pid} =
+      Task.start(fn ->
+        result =
+          try do
+            Director.apply_tsl_delta(director, %{tag => placeholder}, epoch)
+          rescue
+            exception -> {:error, {:placeholder_swap_crashed, Exception.message(exception)}}
+          catch
+            :exit, reason -> {:error, {:placeholder_swap_exited, reason}}
+          end
+
+        GenServer.cast(distributor, {:placeholder_swap_complete, tag, result})
+      end)
+
+    :ok
+  end
+
   # The placeholder is linked (so it dies with the distributor) and its
   # exit is caught via trap_exit above so the distributor can restart it.
   #
   # A restarted placeholder loses its `covered` and `demanded` state while
-  # `pending_demands` here survives, so the recruitment flow (bedrock-q67.5)
-  # must tolerate duplicate `{:coverage_demand, tag}` casts for tags already
-  # pending, and should re-deliver coverage if a delivery races a restart
-  # (a `notify_covered` cast to the dead pid is silently dropped).
+  # `pending_demands` here survives, so `maybe_recruit/2` tolerates
+  # duplicate `{:coverage_demand, tag}` casts for tags already pending, and
+  # the demand handler re-delivers coverage for tags with a live monitored
+  # materializer (a `notify_covered` cast to the dead pid is silently
+  # dropped).
   @spec start_placeholder(State.t()) :: State.t()
   defp start_placeholder(%State{} = t) do
     {:ok, placeholder} =

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -13,9 +13,10 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           transaction_system_layout: TransactionSystemLayout.t() | %{},
           durable_version: Bedrock.version(),
           node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
-          materializer_monitors: %{reference() => Bedrock.range_tag()},
+          materializer_monitors: %{reference() => {Bedrock.range_tag(), pid()}},
           placeholder: pid() | nil,
           pending_demands: MapSet.t(Bedrock.range_tag()),
+          healing: MapSet.t(Bedrock.range_tag()),
           backoff: %{Bedrock.range_tag() => expires_at_ms :: integer()},
           backoff_ms: pos_integer(),
           recruitment_overrides: map()
@@ -30,6 +31,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
             materializer_monitors: %{},
             placeholder: nil,
             pending_demands: MapSet.new(),
+            healing: MapSet.new(),
             backoff: %{},
             backoff_ms: 5_000,
             recruitment_overrides: %{}

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -69,6 +69,33 @@ defmodule Bedrock.ControlPlane.Distributor.Telemetry do
     )
   end
 
+  @spec emit_materializer_down(module(), Bedrock.epoch(), Bedrock.range_tag(), reason :: term()) :: :ok
+  def emit_materializer_down(cluster, epoch, tag, reason) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :materializer_down],
+      %{},
+      %{cluster: cluster, epoch: epoch, tag: tag, reason: reason}
+    )
+  end
+
+  @spec emit_healing_started(module(), Bedrock.epoch(), Bedrock.range_tag()) :: :ok
+  def emit_healing_started(cluster, epoch, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :healing, :started],
+      %{},
+      %{cluster: cluster, epoch: epoch, tag: tag}
+    )
+  end
+
+  @spec emit_healing_completed(module(), Bedrock.epoch(), Bedrock.range_tag()) :: :ok
+  def emit_healing_completed(cluster, epoch, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :healing, :completed],
+      %{},
+      %{cluster: cluster, epoch: epoch, tag: tag}
+    )
+  end
+
   @spec emit_placeholder_parked(module(), Bedrock.range_tag()) :: :ok
   def emit_placeholder_parked(cluster, tag) do
     :telemetry.execute(

--- a/test/bedrock/control_plane/director/component_monitoring_test.exs
+++ b/test/bedrock/control_plane/director/component_monitoring_test.exs
@@ -44,9 +44,10 @@ defmodule Bedrock.ControlPlane.Director.ComponentMonitoringTest do
 
       send(director_pid, {:simulate_component_failure, failed_component_pid, failure_reason})
 
-      # Director should exit immediately with proper shutdown reason
-      assert_receive {:director_exited, ^expected_shutdown_reason}
-      assert_receive {:DOWN, ^monitor_ref, :process, ^director_pid, ^expected_shutdown_reason}
+      # Director should exit immediately with proper shutdown reason.
+      # Generous budget: the default 100ms flakes under full-suite load.
+      assert_receive {:director_exited, ^expected_shutdown_reason}, 1_000
+      assert_receive {:DOWN, ^monitor_ref, :process, ^director_pid, ^expected_shutdown_reason}, 1_000
     end
   end
 end

--- a/test/bedrock/control_plane/distributor/death_healing_integration_test.exs
+++ b/test/bedrock/control_plane/distributor/death_healing_integration_test.exs
@@ -1,0 +1,133 @@
+defmodule Bedrock.ControlPlane.Distributor.DeathHealingIntegrationTest do
+  @moduledoc """
+  Closes the death-healing loop (bedrock-q67.7) end-to-end through the
+  full client read path (PointReads → StorageRacing → LayoutIndex): a read
+  is served by a recruited materializer, the materializer is killed, the
+  next read through the placeholder PARKS (it is not stale-forwarded to
+  the corpse), healing re-recruits a replacement, and the SAME parked read
+  is served again.
+
+  Only the foreman worker-creation boundary is stubbed: the "created"
+  workers are pre-registered StubMaterializer processes speaking the real
+  materializer lock/unlock and read protocols.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State, as: DistributorState
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.PointReads
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"death_healing_integration_#{component}"
+  end
+
+  defmodule CaptureDirector do
+    @moduledoc false
+    use GenServer
+
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_call({:apply_tsl_delta, delta, epoch}, _from, test_pid) do
+      send(test_pid, {:apply_tsl_delta, delta, epoch})
+      {:reply, :ok, test_pid}
+    end
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @epoch 42
+
+  defp client_state(materializer_pid) do
+    layout_index =
+      LayoutIndex.build_index(%{
+        shard_layout: @shard_layout,
+        shard_materializers: %{1 => materializer_pid}
+      })
+
+    %State{
+      state: :valid,
+      layout_index: layout_index,
+      read_version: Version.from_integer(1),
+      fetch_timeout_in_ms: 5_000
+    }
+  end
+
+  defp start_worker(kvs) do
+    name = :"healed_stub_#{System.unique_integer([:positive])}"
+
+    pid =
+      start_supervised!(%{
+        id: name,
+        start: {StubMaterializer, :start_link, [kvs, [name: name]]},
+        restart: :temporary
+      })
+
+    {name, pid}
+  end
+
+  test "read served, materializer killed, next read parks, healing restores service" do
+    {first_name, first_pid} = start_worker(%{"apple" => "red"})
+    {second_name, second_pid} = start_worker(%{"apple" => "red"})
+
+    # Stub ONLY the foreman worker-creation boundary; hand out the two
+    # pre-registered workers in order across recruitment attempts.
+    {:ok, queue} = Agent.start_link(fn -> [first_name, second_name] end)
+
+    recruitment = %{
+      create_worker_fn: fn {_foreman_name, _node}, _worker_id, :materializer, _opts ->
+        {:ok, Agent.get_and_update(queue, fn [next | rest] -> {next, rest} end)}
+      end
+    }
+
+    director = start_supervised!({CaptureDirector, self()}, id: :capture_director)
+
+    distributor =
+      start_supervised!(
+        Distributor.child_spec(
+          cluster: TestCluster,
+          epoch: @epoch,
+          director: director,
+          shard_layout: @shard_layout,
+          node_capabilities: %{materializer: [node()]},
+          durable_version: Version.zero(),
+          otp_name: :"death_healing_integration_#{System.unique_integer([:positive])}",
+          recruitment: recruitment
+        )
+      )
+
+    %DistributorState{placeholder: placeholder} = :sys.get_state(distributor)
+
+    # 1. A read through the full client path recruits the first worker and
+    #    is served by it.
+    state = client_state(placeholder)
+    task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+    assert_receive {:apply_tsl_delta, %{1 => ^first_pid}, @epoch}, 5_000
+    assert {%State{}, {:ok, {"apple", "red"}}} = Task.await(task, 5_000)
+
+    # 2. Kill the materializer: the distributor swaps the placeholder into
+    #    the slot and begins healing.
+    Process.exit(first_pid, :kill)
+    assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+
+    # 3. The next read (stale layout still pointing at the placeholder)
+    #    PARKS - a stale-forward to the corpse could never produce a value -
+    #    and completes once healing recruits the replacement.
+    healed_task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+    assert_receive {:apply_tsl_delta, %{1 => ^second_pid}, @epoch}, 5_000
+    assert {%State{}, {:ok, {"apple", "red"}}} = Task.await(healed_task, 5_000)
+
+    # 4. Once the layout update propagates, reads go direct to the healed
+    #    materializer.
+    direct_state = client_state(second_pid)
+    assert {%State{}, {:ok, {"apple", "red"}}} = PointReads.get_key(direct_state, "apple")
+  end
+end

--- a/test/bedrock/control_plane/distributor/death_healing_test.exs
+++ b/test/bedrock/control_plane/distributor/death_healing_test.exs
@@ -1,0 +1,395 @@
+defmodule Bedrock.ControlPlane.Distributor.DeathHealingTest do
+  @moduledoc """
+  Unit tests for materializer death healing (bedrock-q67.7): the
+  Distributor monitors recruited and recovery-provided materializers; on a
+  materializer's death it swaps the placeholder into the TSL slot
+  (epoch-guarded), uncovers the tag at the placeholder so requests park
+  and re-demand instead of forwarding to the corpse, and eagerly
+  re-recruits under the existing per-tag failure backoff.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"death_healing_#{component}"
+  end
+
+  defmodule CaptureDirector do
+    @moduledoc false
+    use GenServer
+
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_call({:apply_tsl_delta, delta, epoch}, _from, test_pid) do
+      send(test_pid, {:apply_tsl_delta, delta, epoch})
+      {:reply, :ok, test_pid}
+    end
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @version Version.from_integer(1)
+  @epoch 42
+
+  defp unique_otp_name, do: :"death_healing_#{System.unique_integer([:positive])}"
+
+  defp attach_telemetry(test_pid) do
+    handler_id = "death-healing-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :materializer_down],
+        [:bedrock, :distributor, :healing, :started],
+        [:bedrock, :distributor, :healing, :completed],
+        [:bedrock, :distributor, :recruitment, :failed],
+        [:bedrock, :distributor, :placeholder, :parked],
+        [:bedrock, :distributor, :placeholder, :forwarded]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]},
+      restart: :temporary
+    })
+  end
+
+  defp start_distributor(opts) do
+    director = start_supervised!({CaptureDirector, self()}, id: :capture_director)
+
+    pid =
+      start_supervised!(
+        Distributor.child_spec(
+          Keyword.merge(
+            [
+              cluster: TestCluster,
+              epoch: @epoch,
+              director: director,
+              shard_layout: @shard_layout,
+              node_capabilities: %{materializer: [node()]},
+              durable_version: Version.zero(),
+              otp_name: unique_otp_name()
+            ],
+            opts
+          )
+        )
+      )
+
+    {pid, director}
+  end
+
+  # Recruitment seams that hand out a queue of stub materializer pids, one
+  # per recruitment attempt, notifying the test of every worker creation.
+  defp queued_recruitment(test_pid, stubs) do
+    {:ok, queue} = Agent.start_link(fn -> stubs end)
+
+    %{
+      create_worker_fn: fn _foreman, _worker_id, :materializer, _opts ->
+        send(test_pid, :create_worker_called)
+
+        case Agent.get(queue, & &1) do
+          [] -> {:error, :no_capacity}
+          [_next | _rest] -> {:ok, :stub_worker_ref}
+        end
+      end,
+      lock_materializer_fn: fn _worker, _epoch ->
+        {:ok, Agent.get_and_update(queue, fn [next | rest] -> {next, rest} end), %{}}
+      end,
+      unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+    }
+  end
+
+  defp placeholder_of(distributor) do
+    %State{placeholder: placeholder} = :sys.get_state(distributor)
+    placeholder
+  end
+
+  defp park_read(placeholder, key, timeout \\ 5_000) do
+    Task.async(fn -> Materializer.get(placeholder, key, @version, timeout: timeout) end)
+  end
+
+  defp wait_until(fun, deadline_ms \\ 5_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+
+    fn ->
+      if fun.() do
+        :ok
+      else
+        if System.monotonic_time(:millisecond) > deadline, do: flunk("wait_until timed out")
+        Process.sleep(10)
+        :retry
+      end
+    end
+    |> Stream.repeatedly()
+    |> Enum.find(&(&1 == :ok))
+  end
+
+  defp recruit_initial(distributor, stub) do
+    task = park_read(placeholder_of(distributor), "apple")
+    assert_receive {:apply_tsl_delta, %{1 => ^stub}, @epoch}, 5_000
+    assert {:ok, "red"} = Task.await(task, 5_000)
+  end
+
+  describe "monitoring" do
+    test "pre-existing data-shard materializers from the TSL snapshot are monitored; the system shard is not" do
+      system_stub = start_stub(%{})
+      data_stub = start_stub(%{})
+
+      {distributor, _director} =
+        start_distributor(
+          transaction_system_layout: %{
+            shard_materializers: %{0 => system_stub, 1 => data_stub}
+          }
+        )
+
+      assert %State{materializer_monitors: monitors} = :sys.get_state(distributor)
+      assert [{1, ^data_stub}] = Map.values(monitors)
+    end
+
+    test "a successfully recruited materializer is monitored" do
+      stub = start_stub(%{"apple" => "red"})
+      {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [stub]))
+
+      recruit_initial(distributor, stub)
+
+      wait_until(fn ->
+        %State{materializer_monitors: monitors} = :sys.get_state(distributor)
+        Map.values(monitors) == [{1, stub}]
+      end)
+    end
+  end
+
+  describe "healing on materializer death" do
+    test "death of a pre-existing materializer swaps the placeholder into the slot and re-recruits" do
+      attach_telemetry(self())
+      dying = start_stub(%{})
+      replacement = start_stub(%{"apple" => "red"})
+
+      {distributor, _director} =
+        start_distributor(
+          recruitment: queued_recruitment(self(), [replacement]),
+          transaction_system_layout: %{shard_materializers: %{1 => dying}}
+        )
+
+      placeholder = placeholder_of(distributor)
+
+      Process.exit(dying, :kill)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :materializer_down], %{},
+                      %{cluster: TestCluster, epoch: @epoch, tag: 1, reason: :killed}}
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :healing, :started], %{}, %{tag: 1}}
+
+      # The placeholder is swapped into the dead materializer's slot...
+      assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+
+      # ...and re-recruitment runs eagerly, restoring real coverage.
+      assert_receive :create_worker_called, 5_000
+      assert_receive {:apply_tsl_delta, %{1 => ^replacement}, @epoch}, 5_000
+      assert_receive {:telemetry, [:bedrock, :distributor, :healing, :completed], %{}, %{tag: 1}}, 5_000
+
+      # The healed materializer is monitored and the healing set is clear.
+      wait_until(fn ->
+        %State{materializer_monitors: monitors, healing: healing} = :sys.get_state(distributor)
+        Map.values(monitors) == [{1, replacement}] and MapSet.size(healing) == 0
+      end)
+    end
+
+    test "death of a recruited materializer uncovers the tag: the next read parks instead of forwarding" do
+      attach_telemetry(self())
+      dying = start_stub(%{"apple" => "red"})
+      replacement = start_stub(%{"apple" => "blue"})
+      test_pid = self()
+      {:ok, queue} = Agent.start_link(fn -> [dying, replacement] end)
+
+      # Worker creation blocks until the test releases it, so the state of
+      # the placeholder between death and re-recruitment is observable.
+      recruitment = %{
+        create_worker_fn: fn _foreman, _worker_id, :materializer, _opts ->
+          send(test_pid, {:creating, self()})
+
+          receive do
+            :release -> {:ok, :stub_worker_ref}
+          end
+        end,
+        lock_materializer_fn: fn _worker, _epoch ->
+          {:ok, Agent.get_and_update(queue, fn [next | rest] -> {next, rest} end), %{}}
+        end,
+        unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+      }
+
+      {distributor, _director} = start_distributor(recruitment: recruitment)
+      placeholder = placeholder_of(distributor)
+
+      task = park_read(placeholder, "apple")
+      assert_receive {:creating, first_attempt}, 5_000
+      send(first_attempt, :release)
+      assert_receive {:apply_tsl_delta, %{1 => ^dying}, @epoch}, 5_000
+      assert {:ok, "red"} = Task.await(task, 5_000)
+
+      # A stale-layout read forwards through the placeholder while covered.
+      forwarded = park_read(placeholder, "apple")
+      assert {:ok, "red"} = Task.await(forwarded, 5_000)
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :forwarded], %{}, %{tag: 1}}
+
+      Process.exit(dying, :kill)
+      assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+      assert_receive {:creating, second_attempt}, 5_000
+
+      # The placeholder's covered entry for the dead pid is cleared - no
+      # stale-forward black hole.
+      wait_until(fn -> :sys.get_state(placeholder).covered == %{} end)
+
+      # The next read PARKS (a forward to the corpse could never produce a
+      # value) and drains through the replacement once re-recruitment is
+      # released and completes.
+      task = park_read(placeholder, "apple")
+      wait_until(fn -> map_size(:sys.get_state(placeholder).waiting) > 0 end)
+
+      send(second_attempt, :release)
+      assert {:ok, "blue"} = Task.await(task, 5_000)
+      assert_receive {:apply_tsl_delta, %{1 => ^replacement}, @epoch}, 5_000
+    end
+
+    test "the failure backoff is respected when re-recruitment after death fails" do
+      attach_telemetry(self())
+      dying = start_stub(%{"apple" => "red"})
+
+      {distributor, _director} =
+        start_distributor(recruitment: queued_recruitment(self(), [dying]), backoff_ms: 400)
+
+      recruit_initial(distributor, dying)
+      assert_receive :create_worker_called
+      placeholder = placeholder_of(distributor)
+
+      # Death triggers one eager re-recruitment attempt, which fails (the
+      # queue is exhausted) and opens the backoff window.
+      Process.exit(dying, :kill)
+      assert_receive :create_worker_called, 5_000
+      assert_receive {:telemetry, [:bedrock, :distributor, :recruitment, :failed], %{}, %{tag: 1}}, 5_000
+
+      # A read inside the backoff window is shed promptly with :unavailable
+      # and does NOT start another recruitment attempt.
+      task = park_read(placeholder, "apple")
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+      refute_receive :create_worker_called, 100
+
+      # Once the backoff expires, the next read re-demands and recruitment
+      # is retried.
+      Process.sleep(400)
+      task = park_read(placeholder, "apple")
+      assert_receive :create_worker_called, 5_000
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+    end
+
+    test "placeholder restart during healing re-points healed slots at the new placeholder" do
+      dying = start_stub(%{})
+      test_pid = self()
+
+      # Recruitment stalls in flight so the tag stays in healing.
+      recruitment = %{
+        create_worker_fn: fn _foreman, _worker_id, :materializer, _opts ->
+          send(test_pid, {:blocked_recruitment, self()})
+
+          receive do
+            :release -> {:error, :no_capacity}
+          end
+        end
+      }
+
+      {distributor, _director} =
+        start_distributor(
+          recruitment: recruitment,
+          transaction_system_layout: %{shard_materializers: %{1 => dying}}
+        )
+
+      placeholder = placeholder_of(distributor)
+
+      Process.exit(dying, :kill)
+      assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+      assert_receive {:blocked_recruitment, blocked}, 5_000
+
+      Process.exit(placeholder, :kill)
+
+      wait_until(fn -> placeholder_of(distributor) != placeholder end)
+      new_placeholder = placeholder_of(distributor)
+
+      assert_receive {:apply_tsl_delta, %{1 => ^new_placeholder}, @epoch}, 5_000
+
+      send(blocked, :release)
+    end
+  end
+
+  describe "deliver-races-restart" do
+    test "a re-demand after a lost coverage delivery re-delivers the live materializer without recruiting again" do
+      stub = start_stub(%{"apple" => "red"})
+      {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [stub]))
+
+      recruit_initial(distributor, stub)
+      assert_receive :create_worker_called
+      placeholder = placeholder_of(distributor)
+
+      # Simulate the race: the placeholder restarts having never received
+      # the `notify_covered` for the completed recruitment.
+      Process.exit(placeholder, :kill)
+      wait_until(fn -> placeholder_of(distributor) != placeholder end)
+      new_placeholder = placeholder_of(distributor)
+
+      # A read against the restarted placeholder parks and re-demands; the
+      # distributor re-delivers its known-live coverage instead of
+      # recruiting a duplicate materializer.
+      task = park_read(new_placeholder, "apple")
+      assert {:ok, "red"} = Task.await(task, 5_000)
+      refute_receive :create_worker_called, 100
+    end
+  end
+
+  describe "Placeholder.notify_uncovered/2" do
+    test "clears coverage so requests park and re-demand instead of forwarding" do
+      placeholder =
+        start_supervised!(
+          Placeholder.Server.child_spec(
+            cluster: TestCluster,
+            distributor: self(),
+            shard_layout: @shard_layout,
+            hold_ms: 2_000
+          )
+        )
+
+      stub = start_stub(%{"apple" => "red"})
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      task = park_read(placeholder, "apple")
+      assert {:ok, "red"} = Task.await(task, 5_000)
+      refute_receive {:"$gen_cast", {:coverage_demand, 1}}, 100
+
+      :ok = Placeholder.notify_uncovered(placeholder, 1)
+
+      task = park_read(placeholder, "apple")
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(task, 5_000)
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/death_healing_test.exs
+++ b/test/bedrock/control_plane/distributor/death_healing_test.exs
@@ -302,6 +302,25 @@ defmodule Bedrock.ControlPlane.Distributor.DeathHealingTest do
       assert {:error, :unavailable} = Task.await(task, 5_000)
     end
 
+    test "a stale swap-complete for a tag already re-covered does not recruit a duplicate" do
+      stub = start_stub(%{"apple" => "red"})
+      {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [stub]))
+
+      recruit_initial(distributor, stub)
+      assert_receive :create_worker_called
+
+      # Simulate the race: a demand issued between the DOWN and the swap's
+      # completion recruited coverage before {:placeholder_swap_complete, ...}
+      # was processed. The stale swap-complete must not start a second
+      # recruitment (which would orphan the live recruit).
+      GenServer.cast(distributor, {:placeholder_swap_complete, 1, :ok})
+
+      refute_receive :create_worker_called, 100
+
+      %State{materializer_monitors: monitors} = :sys.get_state(distributor)
+      assert Map.values(monitors) == [{1, stub}]
+    end
+
     test "placeholder restart during healing re-points healed slots at the new placeholder" do
       dying = start_stub(%{})
       test_pid = self()

--- a/test/bedrock/control_plane/distributor/placeholder_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_test.exs
@@ -225,7 +225,8 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       placeholder = start_placeholder()
 
       task = async_get(placeholder, "apple", timeout: 5_000)
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      # Generous budget: the default 100ms flakes under full-suite load.
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 1_000
 
       :ok = Placeholder.notify_coverage_failed(placeholder, 1, :no_capacity)
 

--- a/test/bedrock/control_plane/distributor/recruitment_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_test.exs
@@ -10,6 +10,7 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
   import ExUnit.CaptureLog
 
   alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.Recruitment
   alias Bedrock.ControlPlane.Distributor.State
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.DataPlane.Version
@@ -27,7 +28,8 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
     """
     use GenServer
 
-    def start_link(test_pid, reply \\ :ok), do: GenServer.start_link(__MODULE__, {test_pid, reply})
+    def start_link({test_pid, reply}), do: GenServer.start_link(__MODULE__, {test_pid, reply})
+    def start_link(test_pid) when is_pid(test_pid), do: GenServer.start_link(__MODULE__, {test_pid, :ok})
 
     @impl true
     def init(state), do: {:ok, state}
@@ -271,7 +273,7 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
     test "a rejected TSL delta (newer epoch exists) stops the distributor" do
       test_pid = self()
       stub = start_stub(%{})
-      director = start_supervised!({CaptureDirector, [test_pid, {:error, :newer_epoch_exists}]}, id: :stale_director)
+      director = start_supervised!({CaptureDirector, {test_pid, {:error, :newer_epoch_exists}}}, id: :stale_director)
 
       recruitment = %{
         create_worker_fn: fn _foreman, _worker_id, _kind, _opts -> {:ok, :stub_worker_ref} end,
@@ -285,6 +287,86 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
       GenServer.cast(distributor, {:coverage_demand, 1})
 
       assert_receive {:DOWN, ^ref, :process, ^distributor, :normal}, 5_000
+    end
+  end
+
+  describe "orphaned worker cleanup" do
+    defp cleanup_context(test_pid, overrides) do
+      Map.merge(
+        %{
+          cluster: TestCluster,
+          epoch: 42,
+          durable_version: Version.zero(),
+          transaction_system_layout: %{},
+          node_capabilities: %{materializer: [node()]},
+          create_worker_fn: fn _foreman, worker_id, :materializer, _opts ->
+            send(test_pid, {:created, worker_id})
+            {:ok, :stub_worker_ref}
+          end,
+          remove_worker_fn: fn foreman, worker_id, _opts ->
+            send(test_pid, {:removed, foreman, worker_id})
+            :ok
+          end
+        },
+        overrides
+      )
+    end
+
+    test "a created worker whose lock fails is removed" do
+      context = cleanup_context(self(), %{lock_materializer_fn: fn _worker, _epoch -> {:error, :timeout} end})
+
+      assert {:error, {:materializer_lock_failed, :timeout, _node}} = Recruitment.recruit(1, context)
+
+      expected_foreman = {TestCluster.otp_name(:foreman), node()}
+      assert_receive {:created, worker_id}
+      assert_receive {:removed, ^expected_foreman, ^worker_id}
+    end
+
+    test "a locked worker whose unlock fails is removed" do
+      stub = start_stub(%{})
+
+      context =
+        cleanup_context(self(), %{
+          lock_materializer_fn: fn _worker, _epoch -> {:ok, stub, %{}} end,
+          unlock_materializer_fn: fn _pid, _durable_version, _tsl -> {:error, :timeout} end
+        })
+
+      assert {:error, {:unlock_failed, :timeout, _node}} = Recruitment.recruit(1, context)
+
+      expected_foreman = {TestCluster.otp_name(:foreman), node()}
+      assert_receive {:created, worker_id}
+      assert_receive {:removed, ^expected_foreman, ^worker_id}
+    end
+
+    test "a recruited worker whose TSL delta is rejected is removed" do
+      test_pid = self()
+      stub = start_stub(%{})
+      director = start_supervised!({CaptureDirector, {test_pid, {:error, :unavailable}}}, id: :unavailable_director)
+
+      recruitment = %{
+        create_worker_fn: fn _foreman, worker_id, :materializer, _opts ->
+          send(test_pid, {:created, worker_id})
+          {:ok, :stub_worker_ref}
+        end,
+        lock_materializer_fn: fn _worker, _epoch -> {:ok, stub, %{}} end,
+        unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end,
+        remove_worker_fn: fn foreman, worker_id, _opts ->
+          send(test_pid, {:removed, foreman, worker_id})
+          :ok
+        end
+      }
+
+      {distributor, _director} = start_distributor(recruitment: recruitment, director: director)
+
+      GenServer.cast(distributor, {:coverage_demand, 1})
+
+      expected_foreman = {TestCluster.otp_name(:foreman), node()}
+      assert_receive {:created, worker_id}, 5_000
+      assert_receive {:removed, ^expected_foreman, ^worker_id}, 5_000
+
+      # The unfenced recruit was cleaned up and the failure backs off as usual.
+      assert %State{backoff: backoff} = :sys.get_state(distributor)
+      assert Map.has_key?(backoff, 1)
     end
   end
 


### PR DESCRIPTION
Merges `feature/q67-death-healing` (PR #99, commits 8474b7f8 + ca08766a) onto `feature/q67-phase-a` (now containing PR #98's coverage sweep + placeholder_tags), implementing the gating audit's mandatory 6-point reconciliation.

## The 6 points

1. **init combines both**: `state |> start_placeholder() |> monitor_existing_materializers()` with `{:continue, :coverage_sweep}`, so pre-existing snapshot materializers are monitored and the startup sweep still runs first thing.
2. **Healing swap feeds placeholder_tags**: the materializer-DOWN handler now does `MapSet.put(placeholder_tags, tag)` — a healed tag is placeholder-covered and is republished on placeholder restart via #98's `publish_placeholder` mechanism, keeping its pending_demands exclusion and the failure re-assert from 3f606b30. #99's per-tag `swap_placeholder_into_slot` loop over `healing` in the placeholder-EXIT handler is deleted (redundant, and its N single-tag deltas each chained `maybe_recruit`). `healing` remains for telemetry/`complete_healing` only.
3. **recruitment_complete merges both bodies**: `monitor_materializer` + `complete_healing` (#99) + `pending_demands` delete + `placeholder_tags` delete (#98).
4. **state.ex**: keeps #99's `materializer_monitors :: %{reference() => {tag, pid()}}` type and #98's `placeholder_tags` field (clean merge).
5. **Helper unification**: `publish_placeholder/3` is now the single delta-task helper, parameterized by a completion-message constructor. The sweep/restart paths report as `{:sweep_complete, tags, result}`; `swap_placeholder_into_slot/2` is a one-line wrapper reporting `{:placeholder_swap_complete, tag, result}`, preserving the death-swap path's per-tag eager `maybe_recruit` chaining. Rescue reasons unified as `{:placeholder_publish_crashed | :placeholder_publish_exited, ...}` (nothing matched the old atoms).
6. **CaptureDirector**: adopted #99's tuple-arg version; extended with a reply queue (`[:ok, {:error, :newer_epoch_exists}]`) so the rejected-delta test deterministically targets recruitment's own delta now that the startup sweep publishes first — #98's covered-TSL workaround would have been swallowed by #99's covered-tag re-delivery guard.

## Combined-semantics test

New test (`death_healing_test.exs`, "init-time :noproc healing combined with the startup sweep"): a distributor started with a TSL snapshot naming a **dead** materializer pid. The sweep sees the tag as covered and skips it (`coverage_sweep` telemetry with `uncovered: 0`); the init-time `:noproc` DOWN heals it — swap delta to the placeholder observed, eager re-recruitment fires (crash-class death), and after a placeholder restart the slot is republished with the new placeholder pid (point 2's placeholder_tags feed).

Test adaptations for the merged semantics:
- "placeholder restart during healing re-points healed slots": with re-recruitment in flight the restart republish now *skips* the tag (pending_demands exclusion) and the slot is re-asserted when the recruitment fails — asserting both audit-fixed guards survive together.
- Death-healing integration test consumes the startup sweep's delta so its swap assertion can't match the stale sweep message.

## Verification

- distributor + director dirs at 2 seeds: green (59 + 157 tests)
- control_plane + cluster: green (425 tests)
- Full suite: green (2603 tests + 158 properties, 0 failures)
- `mix format`, `credo --strict` clean, dialyzer 0 errors

Do not merge — awaiting gating audit.