### PR TITLE
Materializer idle spin-down: configurable read-inactivity timeout reclaims disk/memory (bedrock-q67.13)

### DIFF
--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -44,6 +44,7 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
           required(:durable_version) => Bedrock.version(),
           required(:transaction_system_layout) => TransactionSystemLayout.t() | %{},
           required(:node_capabilities) => %{Bedrock.Cluster.capability() => [node()]},
+          optional(:worker_params) => %{String.t() => term()},
           optional(:create_worker_fn) => create_worker_fn(),
           optional(:lock_materializer_fn) => lock_materializer_fn(),
           optional(:unlock_materializer_fn) => unlock_materializer_fn(),
@@ -112,12 +113,17 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
     end
   end
 
+  # Worker params (persisted in the worker's manifest) opt recruited
+  # data-shard materializers into per-worker behavior the system shard's
+  # bootstrap never enables - e.g. %{"idle_timeout" => ms} for idle
+  # spin-down (bedrock-q67.13).
   defp create_materializer_worker(node, tag, context) do
     foreman_ref = {context.cluster.otp_name(:foreman), node}
     worker_id = Worker.random_id()
     create_worker_fn = Map.get(context, :create_worker_fn, &Foreman.new_worker/4)
+    worker_params = Map.get(context, :worker_params, %{})
 
-    case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000) do
+    case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000, params: worker_params) do
       {:ok, worker_ref} -> {:ok, worker_ref, worker_id}
       {:error, reason} -> {:error, {:worker_creation_failed, reason, tag, node}}
     end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -27,7 +27,8 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       emit_recruitment_failed: 5,
       emit_materializer_down: 4,
       emit_healing_started: 3,
-      emit_healing_completed: 3
+      emit_healing_completed: 3,
+      emit_idle_spindown: 3
     ]
 
   import Bedrock.Internal.GenServer.Replies
@@ -272,6 +273,31 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     |> noreply()
   end
 
+  # Outcome of the placeholder swap after an idle spin-down. Unlike the
+  # death-healing swap above, no re-recruitment is chained: revival is
+  # demand-driven. A non-epoch failure degrades with a warning only - the
+  # tag stays in placeholder_tags, so a placeholder restart (or a failed
+  # later recruitment) re-asserts the slot, and the LayoutIndex loud
+  # failure remains the backstop.
+  def handle_cast({:idle_swap_complete, _tag, :ok}, %State{} = t), do: noreply(t)
+
+  def handle_cast({:idle_swap_complete, tag, {:error, :newer_epoch_exists}}, %State{} = t) do
+    Logger.info(
+      "Distributor for epoch #{t.epoch} superseded (idle swap for shard tag #{inspect(tag)} rejected); stopping"
+    )
+
+    stop(t, :normal)
+  end
+
+  def handle_cast({:idle_swap_complete, tag, error}, %State{} = t) do
+    Logger.warning(
+      "Distributor for epoch #{t.epoch} failed to swap the placeholder into idle-spun-down shard tag " <>
+        "#{inspect(tag)}: #{inspect(error)}"
+    )
+
+    noreply(t)
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, director, reason}, %State{director: director} = t) do
     Logger.info("Distributor for epoch #{t.epoch} stopping: director exited (#{inspect(reason)})")
@@ -279,31 +305,48 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     stop(t, :normal)
   end
 
-  # A monitored materializer died: heal the shard. The placeholder is told
+  # A monitored materializer exited. A voluntary idle spin-down
+  # (bedrock-q67.13, reason {:shutdown, :idle}) swaps the placeholder into
+  # the slot WITHOUT eager re-recruitment: the shard proved cold, so
+  # revival is demand-driven - the next read parks at the placeholder and
+  # re-demands coverage. Any other exit is a death: heal the shard by
+  # swapping the placeholder into the TSL slot and - once the swap
+  # completes - eagerly re-recruiting. Either way the placeholder is told
   # the tag is uncovered (so requests park and re-demand instead of being
-  # forwarded to the corpse), the placeholder pid is swapped into the TSL
-  # slot, and - once the swap completes - the tag is eagerly re-recruited.
+  # forwarded to the corpse) and the tag becomes placeholder-covered, so a
+  # placeholder restart republishes the new pid into its slot.
   def handle_info({:DOWN, ref, :process, _pid, reason}, %State{} = t) when is_map_key(t.materializer_monitors, ref) do
     {{tag, _pid}, monitors} = Map.pop(t.materializer_monitors, ref)
 
-    Logger.warning(
-      "Distributor for epoch #{t.epoch} healing shard tag #{inspect(tag)}: materializer exited (#{inspect(reason)})"
-    )
-
     if t.placeholder, do: Placeholder.notify_uncovered(t.placeholder, tag)
     emit_materializer_down(t.cluster, t.epoch, tag, reason)
-    emit_healing_started(t.cluster, t.epoch, tag)
 
-    # A healed tag is placeholder-covered: track it in placeholder_tags so a
-    # placeholder restart republishes the new pid into its slot.
-    %{
-      t
-      | materializer_monitors: monitors,
-        healing: MapSet.put(t.healing, tag),
-        placeholder_tags: MapSet.put(t.placeholder_tags, tag)
-    }
-    |> swap_placeholder_into_slot(tag)
-    |> noreply()
+    t = %{t | materializer_monitors: monitors, placeholder_tags: MapSet.put(t.placeholder_tags, tag)}
+
+    case reason do
+      {:shutdown, :idle} ->
+        Logger.info(
+          "Distributor for epoch #{t.epoch} noting idle spin-down of shard tag #{inspect(tag)}: " <>
+            "placeholder coverage, revival on demand"
+        )
+
+        emit_idle_spindown(t.cluster, t.epoch, tag)
+
+        t
+        |> publish_placeholder(MapSet.new([tag]), &{:idle_swap_complete, tag, &1})
+        |> noreply()
+
+      _other ->
+        Logger.warning(
+          "Distributor for epoch #{t.epoch} healing shard tag #{inspect(tag)}: materializer exited (#{inspect(reason)})"
+        )
+
+        emit_healing_started(t.cluster, t.epoch, tag)
+
+        %{t | healing: MapSet.put(t.healing, tag)}
+        |> swap_placeholder_into_slot(tag)
+        |> noreply()
+    end
   end
 
   def handle_info({:EXIT, placeholder, reason}, %State{placeholder: placeholder} = t) do

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -87,6 +87,15 @@ defmodule Bedrock.ControlPlane.Distributor.Telemetry do
     )
   end
 
+  @spec emit_idle_spindown(module(), Bedrock.epoch(), Bedrock.range_tag()) :: :ok
+  def emit_idle_spindown(cluster, epoch, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :idle_spindown],
+      %{},
+      %{cluster: cluster, epoch: epoch, tag: tag}
+    )
+  end
+
   @spec emit_healing_started(module(), Bedrock.epoch(), Bedrock.range_tag()) :: :ok
   def emit_healing_started(cluster, epoch, tag) do
     :telemetry.execute(

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -30,6 +30,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   def startup(otp_name, foreman, id, path, opts \\ []) do
     cluster = Keyword.get(opts, :cluster)
     shard_id = Keyword.get(opts, :shard_id)
+    idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
     snapshot = build_snapshot_handle(cluster, shard_id)
 
     with :ok <- ensure_directory_exists(path),
@@ -45,7 +46,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
          foreman: foreman,
          database: database,
          index_manager: index_manager,
-         snapshot: snapshot
+         snapshot: snapshot,
+         idle_timeout: idle_timeout,
+         last_read_at: System.monotonic_time(:millisecond)
        }}
     end
   end
@@ -157,9 +160,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
         fn -> Database.load_current_durable_version(database) end
       )
 
+    # Grant a fresh idle window after recovery: lock/unlock are not client
+    # reads, but a materializer should never expire mid-recovery epoch
+    # because it spent its window locked.
     t
     |> update_mode(:running)
     |> put_puller(puller)
+    |> Map.put(:last_read_at, System.monotonic_time(:millisecond))
     |> then(&{:ok, &1})
   end
 
@@ -397,6 +404,37 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
           Logger.warning("Snapshot upload failed", version: version_int, reason: inspect(reason))
       end
     end)
+
+    :ok
+  end
+
+  @doc """
+  Best-effort synchronous snapshot upload before an idle spin-down.
+
+  Unlike `maybe_upload_snapshot/4` this runs in the caller: the worker's
+  removal reclaims its working directory right after it exits, so a
+  fire-and-forget task would race the deletion of the very files it reads.
+  A no-op when no snapshot is configured; failures are logged and swallowed
+  (the shard remains rebuildable from earlier snapshots and the logs).
+  """
+  @spec upload_snapshot_before_spindown(State.t()) :: :ok
+  def upload_snapshot_before_spindown(%State{snapshot: nil}), do: :ok
+
+  def upload_snapshot_before_spindown(%State{snapshot: snapshot} = t) do
+    {data_db, index_db} = t.database
+    version_int = t.database |> Database.durable_version() |> Version.to_integer()
+
+    with {:ok, data} <- File.read(to_string(data_db.file_name)),
+         {:ok, idx} <- File.read(to_string(index_db.file_name)),
+         :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
+      Logger.info("Snapshot uploaded to ObjectStorage before idle spin-down", version: version_int)
+    else
+      {:error, reason} ->
+        Logger.warning("Snapshot upload before idle spin-down failed",
+          version: version_int,
+          reason: inspect(reason)
+        )
+    end
 
     :ok
   end

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -14,8 +14,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
   alias Bedrock.DataPlane.Materializer.Olivine.State
+  alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
   alias Bedrock.Service.Foreman
+
+  require Logger
 
   # Transaction count limits for adaptive batching
   # Small batches for responsiveness during normal operation
@@ -29,17 +32,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     foreman = opts[:foreman] || raise "Missing :foreman option"
     id = opts[:id] || raise "Missing :id option"
     path = opts[:path] || raise "Missing :path option"
-    cluster = opts[:cluster]
-    params = opts[:params] || %{}
-    shard_id = params["shard_id"]
-
-    # Build startup opts only if cluster and shard_id are provided
-    startup_opts =
-      if cluster && shard_id do
-        [cluster: cluster, shard_id: shard_id]
-      else
-        []
-      end
+    startup_opts = startup_opts(opts[:cluster], opts[:params] || %{})
 
     %{
       id: {__MODULE__, id},
@@ -53,12 +46,34 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     }
   end
 
+  # Builds the opts handed to Logic.startup/5 from the worker's manifest
+  # params. Cluster and shard_id travel together (they build the snapshot
+  # handle). Idle spin-down is opt-in per worker (bedrock-q67.13): without
+  # an explicit positive idle_timeout the worker never spins down, which is
+  # what exempts the system shard (its bootstrap never sets the param).
+  @spec startup_opts(cluster :: module() | nil, params :: map()) :: keyword()
+  defp startup_opts(cluster, params) do
+    shard_id = params["shard_id"]
+
+    base = if cluster && shard_id, do: [cluster: cluster, shard_id: shard_id], else: []
+
+    case params["idle_timeout"] do
+      idle_timeout when is_integer(idle_timeout) and idle_timeout > 0 ->
+        Keyword.put(base, :idle_timeout, idle_timeout)
+
+      _ ->
+        base
+    end
+  end
+
   @impl true
   def init(args), do: {:ok, args, {:continue, :finish_startup}}
 
   @impl true
 
   def handle_call({:get, key, version, opts}, from, %State{} = t) do
+    t = touch_read_activity(t)
+
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get, key: key})
 
@@ -83,6 +98,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   end
 
   def handle_call({:get_range, start_key, end_key, version, opts}, from, %State{} = t) do
+    t = touch_read_activity(t)
+
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get_range, key: {start_key, end_key}})
 
@@ -203,6 +220,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     case Logic.startup(otp_name, foreman, id, path, opts) do
       {:ok, state} ->
         Telemetry.trace_startup_complete()
+        schedule_idle_check(state)
         noreply(state, continue: :report_health_to_foreman)
 
       {:error, reason} ->
@@ -275,8 +293,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       ) do
     # Atomic cutover to compacted files
     # Get file paths from old database
-    alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
-
     {data_db, index_db} = t.database
     data_path = data_db.file_name
     idx_path = index_db.file_name
@@ -403,6 +419,28 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     noreply(updated_state)
   end
 
+  # Periodic idle check (bedrock-q67.13): only client reads count as
+  # activity - transaction application and pulls keep a shard fresh, not
+  # hot. When the read-inactivity window expires the worker best-effort
+  # uploads a snapshot (when configured), arranges for its foreman entry
+  # (and on-disk working directory) to be removed once it has exited, and
+  # stops with {:shutdown, :idle} so the distributor swaps the placeholder
+  # in WITHOUT eager re-recruitment: demand revives the shard on the next
+  # read.
+  @impl true
+  def handle_info(:idle_check, %State{idle_timeout: :infinity} = t), do: noreply(t)
+
+  def handle_info(:idle_check, %State{} = t) do
+    idle_ms = System.monotonic_time(:millisecond) - t.last_read_at
+
+    if idle_ms >= t.idle_timeout do
+      initiate_idle_spindown(t, idle_ms)
+    else
+      schedule_idle_check(t)
+      noreply(t, continue: :maybe_process_transactions)
+    end
+  end
+
   @impl true
   def handle_info(_msg, state), do: {:noreply, state}
 
@@ -419,6 +457,62 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   def terminate(_reason, _state), do: :ok
 
   defp reply_fn_for(from), do: fn result -> GenServer.reply(from, result) end
+
+  # Idle spin-down
+
+  @spec touch_read_activity(State.t()) :: State.t()
+  defp touch_read_activity(%State{} = t), do: %{t | last_read_at: System.monotonic_time(:millisecond)}
+
+  # Checks run at a quarter of the timeout, so per-read cost stays a single
+  # timestamp write instead of per-request timer churn on the hot path.
+  @spec schedule_idle_check(State.t()) :: State.t()
+  defp schedule_idle_check(%State{idle_timeout: :infinity} = t), do: t
+
+  defp schedule_idle_check(%State{idle_timeout: idle_timeout} = t) do
+    Process.send_after(self(), :idle_check, max(div(idle_timeout, 4), 10))
+    t
+  end
+
+  @spec initiate_idle_spindown(State.t(), non_neg_integer()) :: {:stop, {:shutdown, :idle}, State.t()}
+  defp initiate_idle_spindown(%State{} = t, idle_ms) do
+    OlivineTelemetry.trace_idle_spindown(idle_ms,
+      n_keys: IndexManager.info(t.index_manager, :n_keys),
+      size_in_bytes: IndexManager.info(t.index_manager, :size_in_bytes)
+    )
+
+    Logic.upload_snapshot_before_spindown(t)
+    remove_worker_after_exit(t)
+    stop(t, {:shutdown, :idle})
+  end
+
+  # The foreman entry (and with it the on-disk working directory) is
+  # reclaimed by Foreman.remove_worker/3 - but only after this worker has
+  # actually exited, so the {:shutdown, :idle} exit reason reaches the
+  # distributor's monitor untainted by the supervisor's terminate_child.
+  @spec remove_worker_after_exit(State.t()) :: :ok
+  defp remove_worker_after_exit(%State{foreman: foreman, id: id}) do
+    worker = self()
+
+    spawn(fn ->
+      ref = Process.monitor(worker)
+
+      receive do
+        {:DOWN, ^ref, :process, ^worker, _reason} ->
+          try do
+            Foreman.remove_worker(foreman, id, timeout: 5_000)
+          catch
+            kind, reason ->
+              Logger.warning(
+                "Failed to remove idle materializer worker #{inspect(id)} from foreman: #{inspect({kind, reason})}"
+              )
+          end
+      after
+        30_000 -> :ok
+      end
+    end)
+
+    :ok
+  end
 
   # Calculate min/max key bounds from page_map
   defp calculate_key_bounds_from_pages(page_map) when map_size(page_map) == 0, do: {<<0xFF, 0xFF>>, <<>>}

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -27,7 +27,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           window_lag_time_μs: non_neg_integer(),
           compaction_task: Task.t() | nil,
           allow_window_advancement: boolean(),
-          snapshot: Snapshot.t() | nil
+          snapshot: Snapshot.t() | nil,
+          idle_timeout: pos_integer() | :infinity,
+          last_read_at: integer() | nil
         }
   defstruct otp_name: nil,
             path: nil,
@@ -45,7 +47,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
             window_lag_time_μs: 5_000_000,
             compaction_task: nil,
             allow_window_advancement: true,
-            snapshot: nil
+            snapshot: nil,
+            idle_timeout: :infinity,
+            last_read_at: nil
 
   @spec update_mode(t(), :locked | :running) :: t()
   def update_mode(t, mode), do: %{t | mode: mode}

--- a/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
@@ -89,6 +89,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Telemetry do
     Telemetry.emit_materializer_operation(:compaction_complete, measurements, metadata)
   end
 
+  @spec trace_idle_spindown(non_neg_integer(), keyword()) :: :ok
+  def trace_idle_spindown(idle_duration_ms, opts \\ []) do
+    Telemetry.emit_materializer_operation(
+      :idle_spindown,
+      %{
+        idle_duration_ms: idle_duration_ms,
+        n_keys: Keyword.get(opts, :n_keys, 0),
+        size_in_bytes: Keyword.get(opts, :size_in_bytes, 0)
+      },
+      %{}
+    )
+  end
+
   @spec trace_compaction_failed(term()) :: :ok
   def trace_compaction_failed(reason) do
     Telemetry.emit_materializer_operation(

--- a/lib/bedrock/service/foreman.ex
+++ b/lib/bedrock/service/foreman.ex
@@ -22,15 +22,21 @@ defmodule Bedrock.Service.Foreman do
 
   @doc """
   Create a new worker.
+
+  `:params` are persisted in the worker's manifest and handed back to the
+  worker's `child_spec/1` on every start (keys are strings, matching the
+  manifest's JSON round-trip) - e.g. `%{"idle_timeout" => ms}` opts a
+  materializer into idle spin-down.
   """
   @spec new_worker(
           foreman :: ref(),
           id :: Worker.id(),
           kind :: :log | :materializer,
-          opts :: [timeout: timeout()]
+          opts :: [timeout: timeout(), params: %{String.t() => term()}]
         ) ::
           {:ok, Worker.ref()} | {:error, :timeout}
-  def new_worker(foreman, id, kind, opts \\ []), do: call(foreman, {:new_worker, id, kind}, opts[:timeout] || :infinity)
+  def new_worker(foreman, id, kind, opts \\ []),
+    do: call(foreman, {:new_worker, id, kind, opts[:params] || %{}}, opts[:timeout] || :infinity)
 
   @doc """
   Return a list of running materializer workers only.

--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -35,11 +35,12 @@ defmodule Bedrock.Service.Foreman.Impl do
     |> Enum.map(fn {_id, worker_info} -> compact_service_info_from_worker_info(worker_info) end)
   end
 
-  @spec do_new_worker(State.t(), Worker.id(), :log | :materializer) :: {State.t(), Worker.ref()}
-  def do_new_worker(t, id, kind) do
+  @spec do_new_worker(State.t(), Worker.id(), :log | :materializer, params :: map()) ::
+          {State.t(), Worker.ref()}
+  def do_new_worker(t, id, kind, params \\ %{}) do
     worker_info =
       id
-      |> initialize_new_worker(worker_for_kind(kind), %{}, t.path, t.cluster)
+      |> initialize_new_worker(worker_for_kind(kind), params, t.path, t.cluster)
       |> try_to_start_worker(t.cluster, t.object_storage)
       |> advertise_running_worker(t.cluster)
 

--- a/lib/bedrock/service/foreman/server.ex
+++ b/lib/bedrock/service/foreman/server.ex
@@ -58,6 +58,10 @@ defmodule Bedrock.Service.Foreman.Server do
     do: t |> do_get_all_running_services() |> then(&reply(t, {:ok, &1}))
 
   @impl true
+  def handle_call({:new_worker, id, kind, params}, _from, t),
+    do: t |> do_new_worker(id, kind, params) |> then(fn {t, health} -> reply(t, {:ok, health}) end)
+
+  @impl true
   def handle_call({:new_worker, id, kind}, _from, t),
     do: t |> do_new_worker(id, kind) |> then(fn {t, health} -> reply(t, {:ok, health}) end)
 

--- a/test/bedrock/control_plane/distributor/idle_spindown_test.exs
+++ b/test/bedrock/control_plane/distributor/idle_spindown_test.exs
@@ -1,0 +1,228 @@
+defmodule Bedrock.ControlPlane.Distributor.IdleSpindownTest do
+  @moduledoc """
+  Distributor handling of materializer idle spin-down (bedrock-q67.13):
+  a materializer that exits with `{:shutdown, :idle}` gets the placeholder
+  swapped into its TSL slot (so coverage never has a hard hole) but is NOT
+  eagerly re-recruited - revival is demand-driven, triggered by the next
+  read parking at the placeholder. Any other exit reason keeps the eager
+  death-healing path.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"idle_spindown_#{component}"
+  end
+
+  defmodule CaptureDirector do
+    @moduledoc false
+    use GenServer
+
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_call({:apply_tsl_delta, delta, epoch}, _from, test_pid) do
+      send(test_pid, {:apply_tsl_delta, delta, epoch})
+      {:reply, :ok, test_pid}
+    end
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @version Version.from_integer(1)
+  @epoch 42
+
+  defp unique_otp_name, do: :"idle_spindown_#{System.unique_integer([:positive])}"
+
+  defp attach_telemetry(test_pid) do
+    handler_id = "idle-spindown-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :materializer_down],
+        [:bedrock, :distributor, :idle_spindown],
+        [:bedrock, :distributor, :healing, :started]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]},
+      restart: :temporary
+    })
+  end
+
+  defp start_distributor(opts) do
+    director = start_supervised!({CaptureDirector, self()}, id: :capture_director)
+
+    pid =
+      start_supervised!(
+        Distributor.child_spec(
+          Keyword.merge(
+            [
+              cluster: TestCluster,
+              epoch: @epoch,
+              director: director,
+              shard_layout: @shard_layout,
+              node_capabilities: %{materializer: [node()]},
+              durable_version: Version.zero(),
+              otp_name: unique_otp_name()
+            ],
+            opts
+          )
+        )
+      )
+
+    {pid, director}
+  end
+
+  defp queued_recruitment(test_pid, stubs) do
+    {:ok, queue} = Agent.start_link(fn -> stubs end)
+
+    %{
+      create_worker_fn: fn _foreman, _worker_id, :materializer, _opts ->
+        send(test_pid, :create_worker_called)
+
+        case Agent.get(queue, & &1) do
+          [] -> {:error, :no_capacity}
+          [_next | _rest] -> {:ok, :stub_worker_ref}
+        end
+      end,
+      lock_materializer_fn: fn _worker, _epoch ->
+        {:ok, Agent.get_and_update(queue, fn [next | rest] -> {next, rest} end), %{}}
+      end,
+      unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+    }
+  end
+
+  defp placeholder_of(distributor) do
+    %State{placeholder: placeholder} = :sys.get_state(distributor)
+    placeholder
+  end
+
+  defp park_read(placeholder, key, timeout \\ 5_000) do
+    Task.async(fn -> Materializer.get(placeholder, key, @version, timeout: timeout) end)
+  end
+
+  defp wait_until(fun, deadline_ms \\ 5_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+
+    fn ->
+      if fun.() do
+        :ok
+      else
+        if System.monotonic_time(:millisecond) > deadline, do: flunk("wait_until timed out")
+        Process.sleep(10)
+        :retry
+      end
+    end
+    |> Stream.repeatedly()
+    |> Enum.find(&(&1 == :ok))
+  end
+
+  defp recruit_initial(distributor, stub) do
+    task = park_read(placeholder_of(distributor), "apple")
+    assert_receive {:apply_tsl_delta, %{1 => ^stub}, @epoch}, 5_000
+    assert {:ok, "red"} = Task.await(task, 5_000)
+  end
+
+  test "idle exit swaps the placeholder into the slot but does NOT eagerly re-recruit; the next read revives on demand" do
+    attach_telemetry(self())
+    idle = start_stub(%{"apple" => "red"})
+    replacement = start_stub(%{"apple" => "blue"})
+
+    {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [idle, replacement]))
+
+    recruit_initial(distributor, idle)
+    assert_receive :create_worker_called
+    placeholder = placeholder_of(distributor)
+
+    # The materializer spins itself down after read inactivity.
+    GenServer.stop(idle, {:shutdown, :idle})
+
+    assert_receive {:telemetry, [:bedrock, :distributor, :materializer_down], %{},
+                    %{cluster: TestCluster, epoch: @epoch, tag: 1, reason: {:shutdown, :idle}}}
+
+    assert_receive {:telemetry, [:bedrock, :distributor, :idle_spindown], %{}, %{cluster: TestCluster, tag: 1}}
+
+    # The placeholder is swapped back into the slot...
+    assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+
+    # ...but this is not healing, and no eager re-recruitment happens.
+    refute_receive {:telemetry, [:bedrock, :distributor, :healing, :started], %{}, %{cluster: TestCluster, tag: 1}},
+                   100
+
+    refute_receive :create_worker_called, 200
+
+    # The monitor entry is gone and the tag is placeholder-covered.
+    %State{materializer_monitors: monitors, placeholder_tags: tags, healing: healing} = :sys.get_state(distributor)
+    assert monitors == %{}
+    assert MapSet.member?(tags, 1)
+    assert MapSet.size(healing) == 0
+
+    # The next read parks at the placeholder, demands coverage, and revives
+    # the shard through the normal recruitment flow.
+    task = park_read(placeholder, "apple")
+    assert_receive :create_worker_called, 5_000
+    assert_receive {:apply_tsl_delta, %{1 => ^replacement}, @epoch}, 5_000
+    assert {:ok, "blue"} = Task.await(task, 5_000)
+
+    # The revived materializer is monitored again.
+    wait_until(fn ->
+      %State{materializer_monitors: monitors} = :sys.get_state(distributor)
+      Map.values(monitors) == [{1, replacement}]
+    end)
+  end
+
+  test "non-idle exits keep the eager healing path" do
+    attach_telemetry(self())
+    dying = start_stub(%{"apple" => "red"})
+    replacement = start_stub(%{"apple" => "blue"})
+
+    {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [dying, replacement]))
+
+    recruit_initial(distributor, dying)
+    assert_receive :create_worker_called
+    placeholder = placeholder_of(distributor)
+
+    Process.exit(dying, :kill)
+
+    assert_receive {:telemetry, [:bedrock, :distributor, :healing, :started], %{}, %{cluster: TestCluster, tag: 1}}
+    assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+
+    # Eager re-recruitment fires without any read demand.
+    assert_receive :create_worker_called, 5_000
+    assert_receive {:apply_tsl_delta, %{1 => ^replacement}, @epoch}, 5_000
+  end
+
+  test "a stale idle-swap completion for a tag already re-covered does not recruit" do
+    stub = start_stub(%{"apple" => "red"})
+    {distributor, _director} = start_distributor(recruitment: queued_recruitment(self(), [stub]))
+
+    recruit_initial(distributor, stub)
+    assert_receive :create_worker_called
+
+    GenServer.cast(distributor, {:idle_swap_complete, 1, :ok})
+
+    refute_receive :create_worker_called, 100
+    assert Process.alive?(distributor)
+  end
+end

--- a/test/bedrock/control_plane/distributor/recruitment_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_test.exs
@@ -464,6 +464,47 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
     end
   end
 
+  describe "worker params" do
+    defp params_context(test_pid, overrides) do
+      stub = start_stub(%{})
+
+      Map.merge(
+        %{
+          cluster: TestCluster,
+          epoch: 42,
+          durable_version: Version.zero(),
+          transaction_system_layout: %{},
+          node_capabilities: %{materializer: [node()]},
+          create_worker_fn: fn _foreman, _worker_id, :materializer, opts ->
+            send(test_pid, {:create_worker_opts, opts})
+            {:ok, :stub_worker_ref}
+          end,
+          lock_materializer_fn: fn _worker, _epoch -> {:ok, stub, %{}} end,
+          unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+        },
+        overrides
+      )
+    end
+
+    test "context worker_params are passed to worker creation (idle spin-down opt-in for data shards)" do
+      context = params_context(self(), %{worker_params: %{"idle_timeout" => 300_000}})
+
+      assert {:ok, _pid, _node, _worker_id} = Recruitment.recruit(1, context)
+
+      assert_receive {:create_worker_opts, opts}
+      assert opts[:params] == %{"idle_timeout" => 300_000}
+    end
+
+    test "without worker_params in the context, worker creation gets empty params" do
+      context = params_context(self(), %{})
+
+      assert {:ok, _pid, _node, _worker_id} = Recruitment.recruit(1, context)
+
+      assert_receive {:create_worker_opts, opts}
+      assert opts[:params] == %{}
+    end
+  end
+
   describe "epoch change notifications" do
     test "an older-epoch notification is logged as suspicious and ignored" do
       {distributor, _director} = start_distributor([])

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -66,6 +66,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           director: director,
           shard_layout: Keyword.get(opts, :shard_layout, %{}),
           transaction_system_layout: Keyword.get(opts, :transaction_system_layout, %{}),
+          node_capabilities: Keyword.get(opts, :node_capabilities, %{}),
+          recruitment: Keyword.get(opts, :recruitment, %{}),
           otp_name: unique_otp_name()
         )
       )
@@ -318,10 +320,35 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert Map.has_key?(backoff, 7)
     end
 
+    # The parked read's coverage demand triggers a real recruitment attempt.
+    # With the default empty node_capabilities it fails fast, and its
+    # notify_coverage_failed can race the test's deliver_coverage cast and
+    # shed the parked read first (flaked under full-suite load at seed 77).
+    # Hold the recruitment in flight until this test process exits so the
+    # internal seam alone decides the parked read's fate.
+    defp held_recruitment(test_pid) do
+      %{
+        create_worker_fn: fn _foreman, _worker_id, :materializer, _opts ->
+          ref = Process.monitor(test_pid)
+
+          receive do
+            {:DOWN, ^ref, :process, ^test_pid, _reason} -> {:error, :test_finished}
+          end
+        end
+      }
+    end
+
     test "deliver_coverage relays to the placeholder and clears the pending demand" do
       attach_demand_telemetry(self())
       shard_layout = %{<<0xFF, 0xFF>> => {1, <<>>}}
-      {pid, _director} = start_distributor(shard_layout: shard_layout)
+
+      {pid, _director} =
+        start_distributor(
+          shard_layout: shard_layout,
+          node_capabilities: %{materializer: [node()]},
+          recruitment: held_recruitment(self())
+        )
+
       %State{placeholder: placeholder} = :sys.get_state(pid)
 
       stub =

--- a/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
@@ -1,0 +1,167 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.IdleSpindownTest do
+  @moduledoc """
+  Idle spin-down (bedrock-q67.13): a materializer with a configured
+  `idle_timeout` and no client reads shuts itself down with reason
+  `{:shutdown, :idle}`, best-effort uploads a snapshot when one is
+  configured, and asks its foreman to remove the worker entry (which
+  reclaims the on-disk working directory).
+
+  Tests are deterministic: they rewind the tracked `last_read_at`
+  timestamp via `:sys.replace_state/2` and drive the periodic check by
+  sending `:idle_check` directly, instead of sleeping.
+  """
+  use ExUnit.Case, async: true
+
+  import Bedrock.Test.DataPlane.TransactionTestSupport, only: [new_log_transaction: 2]
+
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Materializer.Olivine
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.ObjectStorage.Snapshot
+
+  @idle_timeout 60_000
+
+  setup do
+    tmp_dir = "/tmp/olivine_idle_#{System.unique_integer([:positive])}"
+    File.rm_rf(tmp_dir)
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  defp start_worker(tmp_dir, params) do
+    worker_id = "worker_#{System.unique_integer([:positive])}"
+    otp_name = :"olivine_idle_#{System.unique_integer([:positive])}"
+
+    child_spec =
+      Olivine.child_spec(
+        otp_name: otp_name,
+        foreman: self(),
+        id: worker_id,
+        path: tmp_dir,
+        params: params
+      )
+
+    {:ok, pid} = start_supervised(Map.put(child_spec, :restart, :temporary))
+
+    # Wait for the worker's health report so startup has completed.
+    assert_receive {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}}, 5_000
+
+    {worker_id, pid}
+  end
+
+  defp rewind_last_read(pid, ms) do
+    :sys.replace_state(pid, fn state ->
+      %{state | last_read_at: System.monotonic_time(:millisecond) - ms}
+    end)
+  end
+
+  defp attach_spindown_telemetry(test_pid) do
+    handler_id = "idle-spindown-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:bedrock, :materializer, :idle_spindown],
+      fn event, measurements, metadata, _ -> send(test_pid, {:telemetry, event, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "idle expiry" do
+    test "with no reads the worker exits {:shutdown, :idle}, emits telemetry, and requests foreman removal",
+         %{tmp_dir: tmp_dir} do
+      attach_spindown_telemetry(self())
+      {worker_id, pid} = start_worker(tmp_dir, %{"idle_timeout" => @idle_timeout})
+      ref = Process.monitor(pid)
+
+      rewind_last_read(pid, @idle_timeout + 1)
+      send(pid, :idle_check)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+
+      assert_receive {:telemetry, [:bedrock, :materializer, :idle_spindown], measurements, _metadata}
+      assert measurements.idle_duration_ms >= @idle_timeout
+
+      # The worker asked its foreman (this test process) to remove its
+      # entry, which is what reclaims the on-disk working directory.
+      assert_receive {:"$gen_call", from, {:remove_worker, ^worker_id}}, 5_000
+      GenServer.reply(from, :ok)
+    end
+
+    test "a real (short) idle_timeout expires on the periodic check without manual driving", %{tmp_dir: tmp_dir} do
+      {_worker_id, pid} = start_worker(tmp_dir, %{"idle_timeout" => 50})
+      ref = Process.monitor(pid)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+    end
+  end
+
+  describe "activity tracking" do
+    test "a read resets the idle timer", %{tmp_dir: tmp_dir} do
+      {_worker_id, pid} = start_worker(tmp_dir, %{"idle_timeout" => @idle_timeout})
+      ref = Process.monitor(pid)
+
+      rewind_last_read(pid, @idle_timeout + 1)
+
+      # A client read arrives before the periodic check fires.
+      Materializer.get(pid, "some_key", Version.zero(), timeout: 1_000)
+
+      send(pid, :idle_check)
+      refute_receive {:DOWN, ^ref, :process, ^pid, _reason}, 200
+      assert Process.alive?(pid)
+    end
+
+    test "transaction application does NOT count as activity", %{tmp_dir: tmp_dir} do
+      {_worker_id, pid} = start_worker(tmp_dir, %{"idle_timeout" => @idle_timeout})
+      ref = Process.monitor(pid)
+
+      rewound_at = System.monotonic_time(:millisecond) - @idle_timeout - 1
+      :sys.replace_state(pid, fn state -> %{state | mode: :running, last_read_at: rewound_at} end)
+
+      # Apply a transaction and wait until it has been processed.
+      send(pid, {:apply_transactions, [new_log_transaction(1, %{"key" => "value"})]})
+
+      assert %{last_read_at: ^rewound_at} = :sys.get_state(pid)
+
+      send(pid, :idle_check)
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+    end
+  end
+
+  describe "snapshot upload on idle exit" do
+    test "a configured snapshot is uploaded before the worker stops", %{tmp_dir: tmp_dir} do
+      object_storage_root = Path.join(tmp_dir, "object_storage")
+      File.mkdir_p!(object_storage_root)
+      backend = ObjectStorage.backend(LocalFilesystem, root: object_storage_root)
+      snapshot = Snapshot.new(backend, "shard_idle_test")
+
+      {_worker_id, pid} = start_worker(Path.join(tmp_dir, "worker"), %{"idle_timeout" => @idle_timeout})
+      ref = Process.monitor(pid)
+
+      :sys.replace_state(pid, fn state -> %{state | snapshot: snapshot} end)
+
+      rewind_last_read(pid, @idle_timeout + 1)
+      send(pid, :idle_check)
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+
+      assert {:ok, _version, _data} = Snapshot.read_latest(snapshot)
+    end
+  end
+
+  describe "exemption" do
+    test "a worker without an explicit idle_timeout never spins down", %{tmp_dir: tmp_dir} do
+      {_worker_id, pid} = start_worker(tmp_dir, %{})
+      ref = Process.monitor(pid)
+
+      rewind_last_read(pid, @idle_timeout * 100)
+      send(pid, :idle_check)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, _reason}, 200
+      assert Process.alive?(pid)
+    end
+  end
+end


### PR DESCRIPTION
Implements bedrock-q67.13: a materializer with a configured read-inactivity timeout shuts itself down gracefully, reclaiming its disk and memory. Coverage falls back to the placeholder; the next read revives the shard through the normal demand-driven recruitment flow. One mechanism, three wins: reaps recruitment orphans without a GC, implements the epic's "zero materializers for cold shards", reclaims resources.

> Built on the death-healing reconciliation (PR #100, merged into `feature/q67-phase-a` while this was in flight), so this PR targets the `feature/q67-phase-a` integration branch directly.

## ⚠️ Default: DISABLED

`idle_timeout` defaults to `:infinity`. **Nothing spins down unless a worker is explicitly opted in** — enabling is a deployment decision. The opt-in path is per-worker: `Foreman.new_worker(..., params: %{"idle_timeout" => ms})`, persisted in the worker's manifest and surviving restarts; the Distributor's recruitment threads it via the `:worker_params` context key (settable through its `recruitment:` opts).

## Design decisions

- **System-shard exemption = exempt-when-unset + explicit per-worker opt-in.** Worker-level shard identity is ambiguous today: nothing in-tree populates the `shard_id` manifest param (olivine's `params["shard_id"]` has no writer), so the worker cannot reliably know it is tag 0. Instead, spin-down requires an explicit `idle_timeout` param; only Distributor recruitment (data shards, by construction) can set it, and the recovery bootstrap never does — so the system shard (and every bootstrap-created materializer) is exempt by construction rather than by a check that could be misconfigured.
- **Activity = client reads only.** `last_read_at` is written on `get`/`get_range` arrival (one timestamp write on the hot path). Transaction application and log pulls do NOT count — they keep a shard fresh, not hot. `unlock_after_recovery` resets the window so a worker never expires because it spent its window locked in recovery.
- **Periodic check, not per-request timers:** `:idle_check` fires every `idle_timeout / 4` (min 10ms) via `Process.send_after`; no timer churn on reads.
- **Graceful exit:** on expiry the worker (1) emits `[:bedrock, :materializer, :idle_spindown]` (idle duration, n_keys, size_in_bytes), (2) **synchronously** best-effort uploads a snapshot when one is configured (synchronous because the directory removal below would race a fire-and-forget task reading the files), (3) arranges `Foreman.remove_worker/3` to run **after** its own exit, and (4) stops with `{:shutdown, :idle}`.
- **Disk IS reclaimed (deletion chosen):** foreman worker removal deletes the worker entry and `rm_rf`s the working directory — the ticket's intent is true reclamation, and ObjectStorage snapshots + logs can rebuild the shard. Tradeoff flagged: revival is a cold start (new worker id, fresh directory, snapshot download + log replay), not a warm restart of the old files. Since demand-driven revival goes through recruitment — which always creates a fresh worker — keeping the old directory would not have produced a warm start anyway. Removal runs only after the worker has exited so the `{:shutdown, :idle}` reason reaches the distributor's monitor untainted by the supervisor's `terminate_child`.
- **Distributor distinguishes idle from death:** `{:shutdown, :idle}` → placeholder swap + `placeholder_tags` + `notify_uncovered` + `[:bedrock, :distributor, :idle_spindown]`, **no eager re-recruitment** (revival is demand-driven; eager healing would fight the spin-down). Any other exit reason keeps the eager healing path unchanged.
- **Olivine only:** basalt's server has no startup-opts/params/cluster plumbing at all (legacy engine; the foreman only creates olivine workers for `:materializer`). Adding spin-down there would mean building that pipeline first for no production benefit — noted and skipped.

## Tests (TDD; deterministic — no sleeps)

Timer tests rewind the tracked `last_read_at` via `:sys.replace_state/2` and drive the periodic check with `send(pid, :idle_check)`; one end-to-end test uses a real 50ms timeout with a bounded `assert_receive`.

- olivine: idle expiry exits `{:shutdown, :idle}`, emits telemetry, requests foreman removal; real short timeout expires unattended; reads reset the timer; transaction application does NOT count as activity; configured snapshot is uploaded before exit; worker without `idle_timeout` never spins down (exemption).
- distributor: idle exit swaps placeholder, `refute create_worker` (no eager recruit), next read parks → demand → revival through recruitment; crash-death still heals eagerly; stale `idle_swap_complete` doesn't recruit.
- recruitment: `worker_params` reach `Foreman.new_worker` (`params:` opt), empty by default.

New tests green at 4 seeds; olivine + distributor + control_plane + service dirs green; full suite green at seeds 12345 and 98765. `mix format`, `credo --strict`, `dialyzer` clean.

Note: `distributor/server_test.exs:321` ("deliver_coverage relays...") flakes under full-suite load — reproduced on the unmodified base branch (seed 77), pre-existing and unrelated.
