### PR TITLE
Treat metadata materializer as transaction-core: death triggers recovery (bedrock-q67.12)

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/monitoring_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/monitoring_phase.ex
@@ -2,9 +2,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhase do
   @moduledoc """
   Sets up monitoring of all transaction system components and marks recovery as complete.
 
-  Establishes process monitoring for sequencer, commit proxies, resolvers, logs,
-  and storage servers. Any failure of these critical components will trigger
-  immediate director shutdown and recovery restart.
+  Establishes process monitoring for the sequencer, commit proxies, resolvers,
+  logs, and the metadata materializer. Any failure of these critical components
+  will trigger immediate director shutdown and recovery restart.
+
+  Data-shard materializers are deliberately excluded: their death-healing is
+  owned by the distributor (placeholder swap + re-recruitment). The metadata
+  materializer (system shard, tag 0) is transaction-core: clients route tag 0
+  through the TSL's `metadata_materializer` field, which the distributor's
+  `shard_materializers` delta cannot update, so its death must trigger a full
+  recovery instead.
 
   This monitoring implements Bedrock's fail-fast philosophy - rather than
   attempting complex error recovery, component failures cause the director
@@ -46,8 +53,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhase do
       [layout.sequencer],
       layout.proxies,
       resolver_pids,
-      service_pids
+      service_pids,
+      metadata_materializer_pid(layout)
     ])
+  end
+
+  # The metadata materializer is monitored via the TSL's dedicated field.
+  # shard_materializers is deliberately never a monitoring source here (the
+  # distributor owns data-shard death-healing), which also means the tag-0
+  # entry — the same pid on a fresh cluster — cannot introduce a second
+  # monitor. If shard_materializers ever becomes a monitoring source, dedupe
+  # against this pid.
+  @spec metadata_materializer_pid(map()) :: [pid()]
+  defp metadata_materializer_pid(layout) do
+    case Map.get(layout, :metadata_materializer) do
+      pid when is_pid(pid) -> [pid]
+      _ -> []
+    end
   end
 
   @spec monitor_all_pids([pid()], (pid() -> reference())) :: [pid()]

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -18,7 +18,9 @@ defmodule Bedrock.ControlPlane.Director.Server do
       try_to_recover: 1
     ]
 
-  import Bedrock.ControlPlane.Director.Telemetry, only: [trace_tsl_delta_applied: 3]
+  import Bedrock.ControlPlane.Director.Telemetry,
+    only: [trace_metadata_materializer_failure: 4, trace_tsl_delta_applied: 3]
+
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config
@@ -131,6 +133,25 @@ defmodule Bedrock.ControlPlane.Director.Server do
     t
     |> maybe_start_distributor()
     |> noreply()
+  end
+
+  def handle_info(
+        {:DOWN, _monitor_ref, :process, failed_pid, reason},
+        %State{transaction_system_layout: %{metadata_materializer: failed_pid}} = t
+      ) do
+    # The metadata materializer is the tag-0 (system shard) read path.
+    # The distributor cannot heal it: clients route tag 0 through the TSL's
+    # metadata_materializer field, which a shard_materializers delta cannot
+    # update. Its death is a core-component failure: stop and let the
+    # coordinator restart recovery, whose bootstrap phase re-creates and
+    # re-locks the system materializer.
+    Logger.error("Metadata materializer (system shard) failed: #{inspect(reason)}; triggering recovery")
+
+    trace_metadata_materializer_failure(t.cluster, t.epoch, failed_pid, reason)
+
+    t
+    |> Map.put(:state, :stopped)
+    |> stop({:shutdown, {:component_failure, failed_pid, reason}})
   end
 
   def handle_info({:DOWN, _monitor_ref, :process, failed_pid, reason}, t) do

--- a/lib/bedrock/control_plane/director/telemetry.ex
+++ b/lib/bedrock/control_plane/director/telemetry.ex
@@ -4,6 +4,26 @@ defmodule Bedrock.ControlPlane.Director.Telemetry do
   alias Bedrock.Telemetry
 
   @doc """
+  Emits a telemetry event indicating that the metadata materializer (system
+  shard, tag 0) died. Its death is a core-component failure: the director
+  stops and the coordinator restarts recovery.
+  """
+  @spec trace_metadata_materializer_failure(
+          cluster :: module(),
+          epoch :: Bedrock.epoch(),
+          pid :: pid(),
+          reason :: term()
+        ) :: :ok
+  def trace_metadata_materializer_failure(cluster, epoch, pid, reason) do
+    Telemetry.execute([:bedrock, :director, :metadata_materializer_failure], %{}, %{
+      cluster: cluster,
+      epoch: epoch,
+      pid: pid,
+      reason: reason
+    })
+  end
+
+  @doc """
   Emits a telemetry event indicating that the director applied a post-recovery
   delta to the transaction system layout's `shard_materializers` map.
   """

--- a/test/bedrock/control_plane/director/component_monitoring_test.exs
+++ b/test/bedrock/control_plane/director/component_monitoring_test.exs
@@ -1,7 +1,10 @@
 defmodule Bedrock.ControlPlane.Director.ComponentMonitoringTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Bedrock.ControlPlane.Director.Server
+  alias Bedrock.ControlPlane.Director.State
 
   describe "component failure handling" do
     test "terminates with shutdown reason when component fails" do
@@ -48,6 +51,64 @@ defmodule Bedrock.ControlPlane.Director.ComponentMonitoringTest do
       # Generous budget: the default 100ms flakes under full-suite load.
       assert_receive {:director_exited, ^expected_shutdown_reason}, 1_000
       assert_receive {:DOWN, ^monitor_ref, :process, ^director_pid, ^expected_shutdown_reason}, 1_000
+    end
+  end
+
+  describe "metadata materializer failure" do
+    test "a :DOWN for the metadata materializer stops the director with component_failure" do
+      materializer = spawn(fn -> :ok end)
+
+      state = %State{
+        state: :running,
+        cluster: __MODULE__,
+        epoch: 7,
+        transaction_system_layout: %{metadata_materializer: materializer}
+      }
+
+      log =
+        capture_log(fn ->
+          assert {:stop, {:shutdown, {:component_failure, ^materializer, :killed}}, stopped} =
+                   Server.handle_info({:DOWN, make_ref(), :process, materializer, :killed}, state)
+
+          assert stopped.state == :stopped
+        end)
+
+      # The log line distinguishes metadata-materializer failure from a
+      # generic component failure.
+      assert log =~ "Metadata materializer"
+    end
+
+    test "a metadata materializer :DOWN emits a distinguishing telemetry event" do
+      test_pid = self()
+      handler_id = {__MODULE__, :metadata_materializer_failure}
+
+      :telemetry.attach(
+        handler_id,
+        [:bedrock, :director, :metadata_materializer_failure],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      materializer = spawn(fn -> :ok end)
+
+      state = %State{
+        state: :running,
+        cluster: __MODULE__,
+        epoch: 7,
+        transaction_system_layout: %{metadata_materializer: materializer}
+      }
+
+      capture_log(fn ->
+        assert {:stop, {:shutdown, {:component_failure, ^materializer, :killed}}, _} =
+                 Server.handle_info({:DOWN, make_ref(), :process, materializer, :killed}, state)
+      end)
+
+      assert_receive {:telemetry, [:bedrock, :director, :metadata_materializer_failure], _measurements,
+                      %{epoch: 7, pid: ^materializer, reason: :killed}}
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/monitoring_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/monitoring_phase_test.exs
@@ -103,6 +103,82 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
       refute_received {:monitored, ^storage_pid}
     end
 
+    test "monitors the metadata materializer (tag 0 is transaction-core)" do
+      metadata_pid = test_process()
+
+      monitor_fn = fn pid ->
+        send(self(), {:monitored, pid})
+        make_ref()
+      end
+
+      recovery_attempt = %{
+        transaction_system_layout: Map.put(create_layout(), :metadata_materializer, metadata_pid)
+      }
+
+      execute_and_verify(recovery_attempt, %{monitor_fn: monitor_fn})
+
+      assert_received {:monitored, ^metadata_pid}
+    end
+
+    test "does not monitor data-shard materializers (distributor-owned healing)" do
+      metadata_pid = test_process()
+      data_shard_pid = test_process()
+
+      monitor_fn = fn pid ->
+        send(self(), {:monitored, pid})
+        make_ref()
+      end
+
+      recovery_attempt = %{
+        transaction_system_layout:
+          create_layout()
+          |> Map.put(:metadata_materializer, metadata_pid)
+          |> Map.put(:shard_materializers, %{0 => metadata_pid, 1 => data_shard_pid})
+      }
+
+      execute_and_verify(recovery_attempt, %{monitor_fn: monitor_fn})
+
+      # The metadata materializer is monitored exactly once, even though the
+      # same pid also appears as shard_materializers[0] (fresh-cluster case).
+      assert_received {:monitored, ^metadata_pid}
+      refute_received {:monitored, ^metadata_pid}
+      # Data-shard materializer death is the distributor's job to heal.
+      refute_received {:monitored, ^data_shard_pid}
+    end
+
+    test "director's mailbox sees :DOWN only for the metadata materializer" do
+      metadata_pid = spawn(fn -> Process.sleep(:infinity) end)
+      data_shard_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      recovery_attempt = %{
+        transaction_system_layout:
+          create_layout()
+          |> Map.put(:metadata_materializer, metadata_pid)
+          |> Map.put(:shard_materializers, %{0 => metadata_pid, 1 => data_shard_pid})
+      }
+
+      # Use the real Process.monitor so :DOWN routing lands in this process,
+      # standing in for the director.
+      execute_and_verify(recovery_attempt, %{})
+
+      Process.exit(data_shard_pid, :kill)
+      refute_receive {:DOWN, _ref, :process, ^data_shard_pid, _reason}, 100
+
+      Process.exit(metadata_pid, :kill)
+      assert_receive {:DOWN, _ref, :process, ^metadata_pid, :killed}
+    end
+
+    test "tolerates a layout without a metadata materializer" do
+      monitor_fn = fn pid ->
+        send(self(), {:monitored, pid})
+        make_ref()
+      end
+
+      recovery_attempt = %{transaction_system_layout: create_layout()}
+
+      execute_and_verify(recovery_attempt, %{monitor_fn: monitor_fn})
+    end
+
     test "crashes if services are not in :up status" do
       down_log_pid = test_process()
 


### PR DESCRIPTION
## Problem (bedrock-q67.12)

The system-shard (tag 0) materializer's death was handled by nobody:

- The distributor deliberately excludes tag 0 from death-healing (`monitor_existing_materializers` skips `@system_shard`), because clients route tag 0 via the TSL's `metadata_materializer` field, which a `shard_materializers` delta cannot update (`LayoutIndex.get_materializer_for_shard/3` prefers `metadata_materializer` for tag 0).
- `MonitoringPhase` filtered out `kind == :materializer` from the director's monitored set.

Net effect: a dead metadata materializer left the system keyspace unreadable until some unrelated event forced a recovery.

## Design choice: (a) metadata materializer is transaction-core

Per the epic's Phase B framing, the TSL retains the genuine transaction core — sequencer, proxies, resolvers, logs, and the metadata materializer (the bootstrap anchor). Core-component death triggers recovery, so the minimal, convention-consistent fix is: the director monitors the `metadata_materializer` pid after recovery, and its death takes the existing component-failure path (`{:shutdown, {:component_failure, pid, reason}}` → coordinator restarts director → recovery).

Option (b) — extending the TSL delta channel so the distributor could heal tag 0 — was rejected: it touches the delta shape, layout routing, and placeholder identity assumptions, and Phase B plans to delete the delta channel, making it throwaway work. No fatal flaw was found in (a).

Recovery genuinely re-establishes tag-0 coverage on both paths of `MaterializerBootstrapPhase`:
- **Fresh cluster**: `create_materializers_for_shards` creates + locks + unlocks the system materializer; a system-shard failure stalls recovery (it never proceeds without tag-0 coverage).
- **Existing cluster**: `handle_existing_cluster` finds-or-creates the tag-0 materializer, locks it for recovery, unlocks it against system-shard logs, waits for catchup, and stalls otherwise.

## Double-monitoring guard analysis

On a fresh cluster the `metadata_materializer` pid is the **same pid** as `shard_materializers[0]`. No double-monitoring or conflicting DOWNs can occur:

- **Distributor side**: `monitor_existing_materializers` explicitly skips `tag == @system_shard`; and tag 0 is always in `covered_tags` whenever `metadata_materializer` is a pid, so the coverage sweep never publishes a placeholder for tag 0, no demand path can recruit it, and `monitor_materializer` never touches it. The distributor never holds a monitor on the tag-0 pid.
- **Director side**: the pid enters the monitored set once, via the dedicated `metadata_materializer` field. `shard_materializers` is deliberately not a monitoring source, and the `services` filter still excludes `kind == :materializer`, so data-shard materializers stay distributor-owned.

## Changes

- `MonitoringPhase.extract_pids_to_monitor/1` includes the `metadata_materializer` pid (tolerates layouts without one). Data-shard materializers remain excluded.
- `Director.Server` adds a `:DOWN` clause matching the TSL's `metadata_materializer`, emitting a distinguishing `Logger.error` and a `[:bedrock, :director, :metadata_materializer_failure]` telemetry event, then stopping with the existing `{:component_failure, pid, reason}` convention (shape unchanged; coordinator behavior unaffected).

## Tests (TDD: written first, 5 red → green)

- MonitoringPhase: metadata materializer is monitored; monitored exactly once when the same pid appears as `shard_materializers[0]`; data-shard materializers are **not** monitored (regression against over-broad monitoring); real-monitor test showing the director's mailbox sees `:DOWN` only for the metadata materializer; tolerates layouts without the field.
- Director server: metadata-materializer `:DOWN` → `{:stop, {:shutdown, {:component_failure, pid, reason}}}` with the distinguishing log line; telemetry event asserted with epoch/pid/reason metadata.
- Existing negative coverage retained: distributor death re-recruits without stopping the director.

## Verification

- Director + distributor tests at seeds 0 and 424242: 239 tests, 0 failures each (one flaky failure on the first seed-0 run did not reproduce across two reruns).
- `control_plane` at seeds 7 and 991: 414 tests, 0 failures.
- Full suite: 13 doctests, 158 properties, 2636 tests, 0 failures (2 excluded).
- `mix format`, `mix credo --strict` (no issues), `mix dialyzer` (0 errors).

Audit note: the generic component-failure clause emits no telemetry for other core components (sequencer/proxies/resolvers/logs); generalizing to a `trace_component_failure` for all of them is deliberately out of scope for this ticket.