### PR TITLE
Wire metadata distribution end-to-end at the commit proxy (bedrock-q67.15)

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -180,14 +180,14 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   During conflict resolution, metadata mutations (keys with \\xFF prefix) are extracted
   from each transaction and sent to the resolver. The resolver returns differential
-  metadata updates that should be merged into the caller's metadata state.
+  metadata updates which are applied to the routing data and handed to the caller's
+  `metadata_merge_fn` (defaults to a no-op) for merging into structured metadata state.
 
   ## Parameters
 
     - `batch`: Transaction batch with commit version details from the sequencer
-    - `transaction_system_layout`: System configuration including resolvers and log servers
-    - `metadata`: Current metadata state (list of accumulated metadata entries)
-    - `opts`: Optional functions for testing and configuration overrides
+    - `opts`: Required configuration (epoch, sequencer, resolver_layout, routing_data)
+      plus optional functions for testing and configuration overrides
 
   ## Returns
 
@@ -207,6 +207,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             resolver_layout: ResolverLayout.t(),
             routing_data: RoutingData.t(),
             resolver_fn: resolver_fn(),
+            metadata_merge_fn: ([MetadataAccumulator.entry()] -> :ok),
             batch_log_push_fn: log_push_batch_fn(),
             abort_reply_fn: abort_reply_fn(),
             success_reply_fn: success_reply_fn(),
@@ -409,8 +410,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   @spec apply_metadata_updates(FinalizationPlan.t(), [MetadataAccumulator.entry()], keyword()) ::
           FinalizationPlan.t()
-  defp apply_metadata_updates(plan, metadata_updates, _opts) do
+  defp apply_metadata_updates(plan, metadata_updates, opts) do
     trace_metadata_updates_received(plan.commit_version, metadata_updates)
+
+    # Hand the version-ordered updates to the caller's merge function so the
+    # commit proxy can fold them into its structured metadata state. Applied at
+    # resolution time (like the routing data below): the resolver has already
+    # accumulated these mutations, regardless of how the rest of the batch fares.
+    metadata_merge_fn = Keyword.get(opts, :metadata_merge_fn, fn _updates -> :ok end)
+    if metadata_updates != [], do: metadata_merge_fn.(metadata_updates)
 
     routing_data = %RoutingData{
       shard_table: plan.shard_table,

--- a/lib/bedrock/data_plane/commit_proxy/metadata.ex
+++ b/lib/bedrock/data_plane/commit_proxy/metadata.ex
@@ -1,0 +1,272 @@
+defmodule Bedrock.DataPlane.CommitProxy.Metadata do
+  @moduledoc """
+  Structured system metadata maintained by the commit proxy.
+
+  The resolver distributes version-ordered windows of committed `\\xFF`
+  system-key mutations back to each commit proxy (see
+  `Bedrock.DataPlane.Resolver.MetadataAccumulator`). This module reduces those
+  updates into a structured, parsed view that mirrors the key families the
+  director writes during recovery persistence
+  (`Bedrock.ControlPlane.Director.Recovery.PersistencePhase`).
+
+  ## Structure
+
+  - `version` - highest commit version applied so far (nil until first update)
+  - `shards` - `shard_key(end_key) -> tag` ceiling-search shard map
+  - `shard_metadata` - `shard(tag) -> encoded ShardMetadata` (kept encoded;
+    FlatBuffer, not `term_to_binary`)
+  - `materializers` - `materializer_key(end_key) -> encoded value` (kept encoded)
+  - `logs` - `layout_log(log_id) -> decoded log descriptor`
+  - `services` - decoded `layout_services` map
+  - `layout_id` - decoded `layout_id`
+  - `cluster` - decoded fixed cluster keys (`:coordinators`, `:epoch`)
+  - `policies` - decoded cluster policies (`:volunteer_nodes`)
+  - `parameters` - decoded cluster parameters (`:desired_logs`, ...)
+  - `recovery` - decoded recovery keys (`:attempt`, `:state`, `:last_completed`)
+  - `legacy` - decoded legacy keys (`:config_monolithic`, `:epoch_legacy`,
+    `:last_recovery_legacy`)
+
+  ## Semantics
+
+  Updates are applied in version order; entries at or below the already-applied
+  `version` are skipped, which makes application idempotent when the resolver
+  re-sends a window to a new caller. Within a version, mutations apply in order
+  (later mutation wins).
+
+  - `{:set, key, value}` - parses the key and stores the (decoded) value
+  - `{:clear, key}` - removes the corresponding entry
+  - `{:clear_range, start_key, end_key}` - removes every known entry whose full
+    system key falls within `[start_key, end_key)`
+  - Unknown or unparseable system keys are ignored (forward compatibility) and
+    counted in the returned stats; the same goes for `{:atomic, ...}` mutations,
+    which are not supported for structured metadata.
+  """
+
+  alias Bedrock.SystemKeys
+
+  @type family ::
+          :shard_key
+          | :shard
+          | :materializer_key
+          | :layout_log
+          | :layout_services
+          | :layout_id
+          | :cluster
+          | :cluster_policy
+          | :cluster_parameter
+          | :recovery
+          | :legacy
+
+  @type stats :: %{applied: non_neg_integer(), families: [family()], skipped_keys: [Bedrock.key()]}
+
+  @type t :: %__MODULE__{
+          version: Bedrock.version() | nil,
+          shards: %{Bedrock.key() => term()},
+          shard_metadata: %{String.t() => binary()},
+          materializers: %{Bedrock.key() => binary()},
+          logs: %{String.t() => term()},
+          services: term() | nil,
+          layout_id: term() | nil,
+          cluster: %{atom() => term()},
+          policies: %{atom() => term()},
+          parameters: %{atom() => term()},
+          recovery: %{atom() => term()},
+          legacy: %{atom() => term()}
+        }
+
+  defstruct version: nil,
+            shards: %{},
+            shard_metadata: %{},
+            materializers: %{},
+            logs: %{},
+            services: nil,
+            layout_id: nil,
+            cluster: %{},
+            policies: %{},
+            parameters: %{},
+            recovery: %{},
+            legacy: %{}
+
+  @doc "Creates empty structured metadata."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Reduces version-ordered metadata updates into the structured metadata.
+
+  Takes updates as returned by the resolver: a list of
+  `{version, [mutation]}` entries in version order (oldest first). Entries with
+  a version at or below the already-applied `version` are skipped.
+
+  Returns `{updated_metadata, stats}` where stats counts applied mutations (with
+  their key families) and skipped unknown/unsupported keys.
+  """
+  @spec apply_updates(t(), [{Bedrock.version(), [term()]}]) :: {t(), stats()}
+  def apply_updates(%__MODULE__{} = metadata, updates) do
+    initial = {metadata, %{applied: 0, families: [], skipped_keys: []}}
+
+    {metadata, stats} =
+      Enum.reduce(updates, initial, fn {version, mutations}, {metadata, stats} = acc ->
+        if metadata.version != nil and version <= metadata.version do
+          acc
+        else
+          {metadata, stats} = Enum.reduce(mutations, {metadata, stats}, &apply_mutation/2)
+          {%{metadata | version: version}, stats}
+        end
+      end)
+
+    {metadata,
+     %{stats | families: Enum.uniq(Enum.reverse(stats.families)), skipped_keys: Enum.reverse(stats.skipped_keys)}}
+  end
+
+  # ============================================================================
+  # Mutation application
+  # ============================================================================
+
+  defp apply_mutation({:set, key, value}, {metadata, stats}) do
+    case SystemKeys.parse_key(key) do
+      parsed when parsed in [:unknown, :error] -> skip(key, {metadata, stats})
+      parsed -> applied(family_of(parsed), {put_entry(metadata, parsed, value), stats})
+    end
+  end
+
+  defp apply_mutation({:clear, key}, {metadata, stats}) do
+    case SystemKeys.parse_key(key) do
+      parsed when parsed in [:unknown, :error] -> skip(key, {metadata, stats})
+      parsed -> applied(family_of(parsed), {delete_entry(metadata, parsed), stats})
+    end
+  end
+
+  defp apply_mutation({:clear_range, start_key, end_key}, {metadata, stats}) do
+    in_range =
+      metadata
+      |> known_entries()
+      |> Enum.filter(fn {full_key, _parsed} -> full_key >= start_key and full_key < end_key end)
+
+    metadata = Enum.reduce(in_range, metadata, fn {_full_key, parsed}, metadata -> delete_entry(metadata, parsed) end)
+
+    families = Enum.map(in_range, fn {_full_key, parsed} -> family_of(parsed) end)
+    {metadata, %{stats | applied: stats.applied + 1, families: Enum.reverse(families, stats.families)}}
+  end
+
+  # Atomic operations are not supported for structured metadata
+  defp apply_mutation({:atomic, _op, key, _value}, {metadata, stats}), do: skip(key, {metadata, stats})
+
+  defp skip(key, {metadata, stats}), do: {metadata, %{stats | skipped_keys: [key | stats.skipped_keys]}}
+
+  defp applied(family, {metadata, stats}),
+    do: {metadata, %{stats | applied: stats.applied + 1, families: [family | stats.families]}}
+
+  defp family_of({family, _param}), do: family
+
+  defp family_of(legacy) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy], do: :legacy
+
+  defp family_of(family) when is_atom(family), do: family
+
+  # ============================================================================
+  # Entry storage (parsed key -> struct slot)
+  # ============================================================================
+
+  # Values written by PersistencePhase are term_to_binary encoded, except
+  # shard/1 (FlatBuffer ShardMetadata) and materializer_key/1, which are kept
+  # encoded. Encoding will change under bedrock-ri40; decode stays centralized here.
+  defp put_entry(metadata, {:shard_key, end_key}, value),
+    do: %{metadata | shards: Map.put(metadata.shards, end_key, decode(value))}
+
+  defp put_entry(metadata, {:shard, tag}, value),
+    do: %{metadata | shard_metadata: Map.put(metadata.shard_metadata, tag, value)}
+
+  defp put_entry(metadata, {:materializer_key, end_key}, value),
+    do: %{metadata | materializers: Map.put(metadata.materializers, end_key, value)}
+
+  defp put_entry(metadata, {:layout_log, log_id}, value),
+    do: %{metadata | logs: Map.put(metadata.logs, log_id, decode(value))}
+
+  defp put_entry(metadata, :layout_services, value), do: %{metadata | services: decode(value)}
+  defp put_entry(metadata, :layout_id, value), do: %{metadata | layout_id: decode(value)}
+
+  defp put_entry(metadata, {:cluster, name}, value),
+    do: %{metadata | cluster: Map.put(metadata.cluster, name, decode(value))}
+
+  defp put_entry(metadata, {:cluster_policy, name}, value),
+    do: %{metadata | policies: Map.put(metadata.policies, name, decode(value))}
+
+  defp put_entry(metadata, {:cluster_parameter, name}, value),
+    do: %{metadata | parameters: Map.put(metadata.parameters, name, decode(value))}
+
+  defp put_entry(metadata, {:recovery, name}, value),
+    do: %{metadata | recovery: Map.put(metadata.recovery, name, decode(value))}
+
+  defp put_entry(metadata, legacy, value) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
+    do: %{metadata | legacy: Map.put(metadata.legacy, legacy, decode(value))}
+
+  defp delete_entry(metadata, {:shard_key, end_key}), do: %{metadata | shards: Map.delete(metadata.shards, end_key)}
+
+  defp delete_entry(metadata, {:shard, tag}), do: %{metadata | shard_metadata: Map.delete(metadata.shard_metadata, tag)}
+
+  defp delete_entry(metadata, {:materializer_key, end_key}),
+    do: %{metadata | materializers: Map.delete(metadata.materializers, end_key)}
+
+  defp delete_entry(metadata, {:layout_log, log_id}), do: %{metadata | logs: Map.delete(metadata.logs, log_id)}
+  defp delete_entry(metadata, :layout_services), do: %{metadata | services: nil}
+  defp delete_entry(metadata, :layout_id), do: %{metadata | layout_id: nil}
+  defp delete_entry(metadata, {:cluster, name}), do: %{metadata | cluster: Map.delete(metadata.cluster, name)}
+  defp delete_entry(metadata, {:cluster_policy, name}), do: %{metadata | policies: Map.delete(metadata.policies, name)}
+
+  defp delete_entry(metadata, {:cluster_parameter, name}),
+    do: %{metadata | parameters: Map.delete(metadata.parameters, name)}
+
+  defp delete_entry(metadata, {:recovery, name}), do: %{metadata | recovery: Map.delete(metadata.recovery, name)}
+
+  defp delete_entry(metadata, legacy) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
+    do: %{metadata | legacy: Map.delete(metadata.legacy, legacy)}
+
+  defp decode(value), do: :erlang.binary_to_term(value)
+
+  # ============================================================================
+  # clear_range support: enumerate every stored entry with its full system key
+  # ============================================================================
+
+  defp known_entries(metadata) do
+    Enum.concat([
+      Enum.map(metadata.shards, fn {end_key, _} -> {SystemKeys.shard_key(end_key), {:shard_key, end_key}} end),
+      Enum.map(metadata.shard_metadata, fn {tag, _} -> {SystemKeys.shards_prefix() <> tag, {:shard, tag}} end),
+      Enum.map(metadata.materializers, fn {end_key, _} ->
+        {SystemKeys.materializer_key(end_key), {:materializer_key, end_key}}
+      end),
+      Enum.map(metadata.logs, fn {log_id, _} -> {SystemKeys.layout_log(log_id), {:layout_log, log_id}} end),
+      if(metadata.services == nil, do: [], else: [{SystemKeys.layout_services(), :layout_services}]),
+      if(metadata.layout_id == nil, do: [], else: [{SystemKeys.layout_id(), :layout_id}]),
+      Enum.map(metadata.cluster, fn {name, _} -> {cluster_key(name), {:cluster, name}} end),
+      Enum.map(metadata.policies, fn {name, _} -> {policy_key(name), {:cluster_policy, name}} end),
+      Enum.map(metadata.parameters, fn {name, _} -> {parameter_key(name), {:cluster_parameter, name}} end),
+      Enum.map(metadata.recovery, fn {name, _} -> {recovery_key(name), {:recovery, name}} end),
+      Enum.map(metadata.legacy, fn {name, _} -> {legacy_key(name), name} end)
+    ])
+  end
+
+  defp cluster_key(:coordinators), do: SystemKeys.cluster_coordinators()
+  defp cluster_key(:epoch), do: SystemKeys.cluster_epoch()
+
+  defp policy_key(:volunteer_nodes), do: SystemKeys.cluster_policies_volunteer_nodes()
+
+  defp parameter_key(:desired_logs), do: SystemKeys.cluster_parameters_desired_logs()
+  defp parameter_key(:desired_replication), do: SystemKeys.cluster_parameters_desired_replication()
+  defp parameter_key(:desired_commit_proxies), do: SystemKeys.cluster_parameters_desired_commit_proxies()
+  defp parameter_key(:desired_coordinators), do: SystemKeys.cluster_parameters_desired_coordinators()
+  defp parameter_key(:desired_read_version_proxies), do: SystemKeys.cluster_parameters_desired_read_version_proxies()
+
+  defp parameter_key(:empty_transaction_timeout_ms), do: SystemKeys.cluster_parameters_empty_transaction_timeout_ms()
+
+  defp parameter_key(:ping_rate_in_hz), do: SystemKeys.cluster_parameters_ping_rate_in_hz()
+  defp parameter_key(:retransmission_rate_in_hz), do: SystemKeys.cluster_parameters_retransmission_rate_in_hz()
+  defp parameter_key(:transaction_window_in_ms), do: SystemKeys.cluster_parameters_transaction_window_in_ms()
+
+  defp recovery_key(:attempt), do: SystemKeys.recovery_attempt()
+  defp recovery_key(:state), do: SystemKeys.recovery_state()
+  defp recovery_key(:last_completed), do: SystemKeys.recovery_last_completed()
+
+  defp legacy_key(:config_monolithic), do: SystemKeys.config_monolithic()
+  defp legacy_key(:epoch_legacy), do: SystemKeys.epoch_legacy()
+  defp legacy_key(:last_recovery_legacy), do: SystemKeys.last_recovery_legacy()
+end

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -47,12 +47,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   import Bedrock.DataPlane.CommitProxy.Finalization, only: [finalize_batch: 2]
 
   import Bedrock.DataPlane.CommitProxy.Telemetry,
-    only: [trace_metadata: 0, trace_metadata: 1]
+    only: [trace_metadata: 0, trace_metadata: 1, trace_metadata_applied: 2, trace_unknown_key_skipped: 1]
 
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.Cluster
   alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.CommitProxy.State
@@ -196,7 +197,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
   @impl true
-  @spec handle_info(:timeout | {:routing_data_update, RoutingData.t()}, State.t()) ::
+  @spec handle_info(:timeout | {:routing_data_update, RoutingData.t()} | {:metadata_updates, [term()]}, State.t()) ::
           {:noreply, State.t(), timeout()}
   def handle_info(:timeout, %{batch: nil, mode: :running} = t) do
     empty_transaction = Transaction.empty_transaction()
@@ -232,6 +233,14 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     noreply(%{t | routing_data: updated_routing_data})
   end
 
+  def handle_info({:metadata_updates, updates}, %{mode: :running} = t) do
+    noreply(apply_metadata_updates(t, updates), timeout: t.empty_transaction_timeout_ms)
+  end
+
+  def handle_info({:metadata_updates, updates}, t) do
+    noreply(apply_metadata_updates(t, updates))
+  end
+
   def handle_info({:DOWN, _ref, :process, director_pid, _reason}, %{director: director_pid} = t) do
     # Director has died - this commit proxy should terminate gracefully
     {:stop, :normal, t}
@@ -259,7 +268,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
              epoch: epoch,
              sequencer: sequencer,
              resolver_layout: resolver_layout,
-             routing_data: routing_data
+             routing_data: routing_data,
+             metadata_merge_fn: fn updates -> send(server_pid, {:metadata_updates, updates}) end
            ) do
         {:ok, _n_aborts, _n_oks, updated_routing_data} ->
           send(server_pid, {:routing_data_update, updated_routing_data})
@@ -268,6 +278,20 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           exit(reason)
       end
     end)
+  end
+
+  # Folds version-ordered metadata updates from the resolver into the proxy's
+  # structured metadata. Applied in the server process so updates from
+  # concurrent finalization tasks are serialized; the version guard inside
+  # Metadata.apply_updates makes redelivered windows idempotent.
+  @spec apply_metadata_updates(State.t(), [term()]) :: State.t()
+  defp apply_metadata_updates(t, updates) do
+    {metadata, stats} = Metadata.apply_updates(t.metadata, updates)
+
+    if stats.applied > 0, do: trace_metadata_applied(stats.applied, stats.families)
+    if stats.skipped_keys != [], do: trace_unknown_key_skipped(stats.skipped_keys)
+
+    %{t | metadata: metadata}
   end
 
   @spec reply_fn(GenServer.from()) :: Batch.reply_fn()

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -2,6 +2,7 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
   @moduledoc false
 
   alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.RoutingData
 
@@ -19,7 +20,8 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           empty_transaction_timeout_ms: non_neg_integer(),
           mode: mode(),
           lock_token: binary(),
-          routing_data: RoutingData.t() | nil
+          routing_data: RoutingData.t() | nil,
+          metadata: Metadata.t()
         }
   defstruct cluster: nil,
             director: nil,
@@ -32,5 +34,6 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             empty_transaction_timeout_ms: nil,
             mode: :locked,
             lock_token: nil,
-            routing_data: nil
+            routing_data: nil,
+            metadata: %Metadata{}
 end

--- a/lib/bedrock/data_plane/commit_proxy/telemetry.ex
+++ b/lib/bedrock/data_plane/commit_proxy/telemetry.ex
@@ -54,6 +54,24 @@ defmodule Bedrock.DataPlane.CommitProxy.Telemetry do
     )
   end
 
+  @spec trace_metadata_applied(count :: non_neg_integer(), families :: [atom()]) :: :ok
+  def trace_metadata_applied(count, families) do
+    Telemetry.execute(
+      [:bedrock, :data_plane, :commit_proxy, :metadata_applied],
+      %{count: count},
+      Map.put(trace_metadata(), :families, families)
+    )
+  end
+
+  @spec trace_unknown_key_skipped(keys :: [Bedrock.key()]) :: :ok
+  def trace_unknown_key_skipped(keys) do
+    Telemetry.execute(
+      [:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped],
+      %{count: length(keys)},
+      Map.put(trace_metadata(), :keys, keys)
+    )
+  end
+
   @spec trace_metadata_updates_received(
           commit_version :: Bedrock.version(),
           metadata_updates :: [term()]

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -204,11 +204,20 @@ defmodule Bedrock.SystemKeys do
   @doc """
   Parses a system key and extracts its type and parameter.
 
+  This is the inverse of the key generation functions above and covers every
+  key family written by the director's recovery persistence phase.
+
   Returns:
   - `{:layout_log, log_id}` for log keys
   - `{:shard_key, end_key}` for shard key mappings
   - `{:shard, tag}` for shard metadata keys
   - `{:materializer_key, end_key}` for materializer keys
+  - `:layout_services` / `:layout_id` for fixed layout keys
+  - `{:cluster, :coordinators | :epoch}` for fixed cluster keys
+  - `{:cluster_policy, :volunteer_nodes}` for cluster policies
+  - `{:cluster_parameter, name}` for known cluster parameters
+  - `{:recovery, :attempt | :state | :last_completed}` for recovery keys
+  - `:config_monolithic` / `:epoch_legacy` / `:last_recovery_legacy` for legacy keys
   - `:unknown` for unrecognized system keys
   - `:error` for non-system keys
   """
@@ -217,6 +226,15 @@ defmodule Bedrock.SystemKeys do
           | {:shard_key, String.t()}
           | {:shard, String.t()}
           | {:materializer_key, String.t()}
+          | :layout_services
+          | :layout_id
+          | {:cluster, :coordinators | :epoch}
+          | {:cluster_policy, :volunteer_nodes}
+          | {:cluster_parameter, atom()}
+          | {:recovery, :attempt | :state | :last_completed}
+          | :config_monolithic
+          | :epoch_legacy
+          | :last_recovery_legacy
           | :unknown
           | :error
   # Order matters: more specific prefixes first (shard_keys before shards)
@@ -224,7 +242,38 @@ defmodule Bedrock.SystemKeys do
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
   def parse_key(<<@system_prefix, "/shards/", rest::binary>>), do: {:shard, rest}
   def parse_key(<<@system_prefix, "/materializer_keys/", rest::binary>>), do: {:materializer_key, rest}
+  def parse_key(<<@system_prefix, "/layout/services">>), do: :layout_services
+  def parse_key(<<@system_prefix, "/layout/id">>), do: :layout_id
+  def parse_key(<<@system_prefix, "/cluster/coordinators">>), do: {:cluster, :coordinators}
+  def parse_key(<<@system_prefix, "/cluster/epoch">>), do: {:cluster, :epoch}
+  def parse_key(<<@system_prefix, "/cluster/policies/volunteer_nodes">>), do: {:cluster_policy, :volunteer_nodes}
+  def parse_key(<<@system_prefix, "/cluster/parameters/", rest::binary>>), do: parse_cluster_parameter(rest)
+  def parse_key(<<@system_prefix, "/recovery/attempt">>), do: {:recovery, :attempt}
+  def parse_key(<<@system_prefix, "/recovery/state">>), do: {:recovery, :state}
+  def parse_key(<<@system_prefix, "/recovery/last_completed">>), do: {:recovery, :last_completed}
+  def parse_key(<<@system_prefix, "/config">>), do: :config_monolithic
+  def parse_key(<<@system_prefix, "/epoch">>), do: :epoch_legacy
+  def parse_key(<<@system_prefix, "/last_recovery">>), do: :last_recovery_legacy
   def parse_key(<<@system_prefix, _rest::binary>>), do: :unknown
   def parse_key(key) when is_binary(key), do: :error
   def parse_key(_), do: :error
+
+  # Known cluster parameters only; unknown parameters are forward-compatible
+  @cluster_parameters ~w(
+    desired_logs
+    desired_replication
+    desired_commit_proxies
+    desired_coordinators
+    desired_read_version_proxies
+    empty_transaction_timeout_ms
+    ping_rate_in_hz
+    retransmission_rate_in_hz
+    transaction_window_in_ms
+  )
+
+  for name <- @cluster_parameters do
+    defp parse_cluster_parameter(unquote(name)), do: {:cluster_parameter, unquote(String.to_atom(name))}
+  end
+
+  defp parse_cluster_parameter(_), do: :unknown
 end

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -1,0 +1,254 @@
+defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
+  @moduledoc """
+  End-to-end integration tests for the \\xFF system metadata distribution
+  pipeline (bedrock-q67.15).
+
+  A committed transaction carrying a system-key mutation flows through:
+
+      commit proxy (extract) -> resolver (MetadataAccumulator) ->
+      commit proxy (parse + apply into structured State.metadata)
+
+  Uses a real Sequencer.Server, a real Resolver.Server, and a real
+  CommitProxy.Server; only the log is faked (established seam).
+  """
+  use ExUnit.Case, async: false
+
+  import Bedrock.Test.TelemetryTestHelper
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
+  alias Bedrock.DataPlane.Resolver.MetadataAccumulator
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Sequencer.Server, as: SequencerServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component) when is_atom(component), do: :"metadata_dist_test_#{component}"
+  end
+
+  # Fake log that always accepts pushes (established DI seam)
+  defmodule FakeLog do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_opts), do: GenServer.start_link(__MODULE__, %{})
+
+    def init(state), do: {:ok, state}
+
+    def handle_call({:push, _transaction, _last_commit_version}, _from, state), do: {:reply, :ok, state}
+  end
+
+  setup do
+    director = self()
+    epoch = 1
+    lock_token = :crypto.strong_rand_bytes(32)
+
+    sequencer =
+      start_supervised!(
+        {SequencerServer,
+         [
+           cluster: TestCluster,
+           otp_name: :metadata_dist_test_sequencer,
+           director: director,
+           epoch: epoch,
+           last_committed_version: Version.zero()
+         ]}
+      )
+
+    resolver =
+      start_supervised!(
+        {ResolverServer,
+         [
+           lock_token: lock_token,
+           key_range: {"", <<0xFF, 0xFF>>},
+           epoch: epoch,
+           last_version: Version.zero(),
+           director: director,
+           cluster: TestCluster
+         ]}
+      )
+
+    log = start_supervised!({FakeLog, []})
+
+    resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver}]})
+
+    shard_table = :ets.new(:metadata_dist_test_shards, [:ordered_set, :public])
+    # Single shard (tag 0) covering the entire keyspace, system keys included
+    :ets.insert(shard_table, {<<0xFF, 0xFF>>, 0})
+
+    routing_data = %RoutingData{
+      shard_table: shard_table,
+      log_map: %{0 => "log_1"},
+      log_services: %{"log_1" => log},
+      replication_factor: 1
+    }
+
+    proxy =
+      start_supervised!(
+        CommitProxyServer.child_spec(
+          cluster: TestCluster,
+          director: director,
+          epoch: epoch,
+          instance: 0,
+          max_latency_in_ms: 1,
+          max_per_batch: 10,
+          empty_transaction_timeout_ms: 60_000,
+          lock_token: lock_token,
+          sequencer: sequencer,
+          resolver_layout: resolver_layout,
+          routing_data: routing_data
+        )
+      )
+
+    :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data})
+
+    %{proxy: proxy, resolver: resolver, epoch: epoch}
+  end
+
+  defp encode_tx(mutations, conflict_key) do
+    Transaction.encode(%{
+      mutations: mutations,
+      read_conflicts: [],
+      write_conflicts: [{conflict_key, conflict_key <> <<0>>}]
+    })
+  end
+
+  defp commit!(proxy, epoch, mutations, conflict_key) do
+    assert {:ok, version, _index} = GenServer.call(proxy, {:commit, epoch, encode_tx(mutations, conflict_key)}, 5_000)
+
+    version
+  end
+
+  # Poll until condition is met (metadata application is asynchronous)
+  defp wait_until(condition_fn, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(condition_fn, deadline)
+  end
+
+  defp do_wait_until(condition_fn, deadline) do
+    if condition_fn.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(10)
+        do_wait_until(condition_fn, deadline)
+      else
+        flunk("Condition not met before timeout")
+      end
+    end
+  end
+
+  defp proxy_metadata(proxy), do: :sys.get_state(proxy).metadata
+
+  test "system-key mutation flows commit -> resolver accumulator -> parsed proxy metadata", %{
+    proxy: proxy,
+    resolver: resolver,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("m")
+    encoded_tag = :erlang.term_to_binary(7)
+
+    version =
+      commit!(
+        proxy,
+        epoch,
+        [{:set, "user_key", "user_value"}, {:set, shard_key, encoded_tag}],
+        "user_key"
+      )
+
+    # 1. The resolver's MetadataAccumulator captured the system-key mutation
+    #    at the batch's commit version.
+    resolver_entries = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
+    assert {^version, [{:set, ^shard_key, ^encoded_tag}]} = List.keyfind(resolver_entries, version, 0)
+
+    # 2. The commit proxy's post-batch state contains the PARSED structured entry.
+    wait_until(fn -> proxy_metadata(proxy).shards != %{} end)
+
+    assert %Metadata{shards: %{"m" => 7}, version: ^version} = proxy_metadata(proxy)
+  end
+
+  test "metadata updates arrive ordered across multiple batches; later value wins", %{
+    proxy: proxy,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("m")
+
+    _v1 = commit!(proxy, epoch, [{:set, shard_key, :erlang.term_to_binary(7)}], "key_a")
+    wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 7} end)
+
+    v2 = commit!(proxy, epoch, [{:set, shard_key, :erlang.term_to_binary(9)}], "key_b")
+    wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 9} end)
+
+    assert %Metadata{shards: %{"m" => 9}, version: ^v2} = proxy_metadata(proxy)
+  end
+
+  test "a non-system mutation never pollutes metadata", %{proxy: proxy, resolver: resolver, epoch: epoch} do
+    commit!(proxy, epoch, [{:set, "plain_key", "plain_value"}], "plain_key")
+
+    # Give the pipeline a moment to (incorrectly) deliver anything
+    Process.sleep(100)
+
+    assert MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window) == []
+    assert proxy_metadata(proxy) == Metadata.new()
+  end
+
+  test "multiple key families parse into their structured slots", %{proxy: proxy, epoch: epoch} do
+    mutations = [
+      {:set, SystemKeys.shard_key("g"), :erlang.term_to_binary(3)},
+      {:set, SystemKeys.layout_log("log-abc"), :erlang.term_to_binary([0, 1])},
+      {:set, SystemKeys.layout_services(), :erlang.term_to_binary(%{"log-abc" => %{kind: :log}})},
+      {:set, SystemKeys.cluster_epoch(), :erlang.term_to_binary(1)},
+      {:set, SystemKeys.cluster_parameters_desired_logs(), :erlang.term_to_binary(2)},
+      {:set, SystemKeys.recovery_attempt(), :erlang.term_to_binary(1)}
+    ]
+
+    version = commit!(proxy, epoch, mutations, "families_key")
+
+    wait_until(fn -> proxy_metadata(proxy).version == version end)
+
+    metadata = proxy_metadata(proxy)
+    assert metadata.shards == %{"g" => 3}
+    assert metadata.logs == %{"log-abc" => [0, 1]}
+    assert metadata.services == %{"log-abc" => %{kind: :log}}
+    assert metadata.cluster == %{epoch: 1}
+    assert metadata.parameters == %{desired_logs: 2}
+    assert metadata.recovery == %{attempt: 1}
+  end
+
+  test "unknown system keys are ignored and counted in telemetry", %{proxy: proxy, epoch: epoch} do
+    attach_telemetry_reflector(
+      self(),
+      [
+        [:bedrock, :data_plane, :commit_proxy, :metadata_applied],
+        [:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped]
+      ],
+      "metadata-distribution-telemetry"
+    )
+
+    mutations = [
+      {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(5)},
+      {:set, <<0xFF, "/system/future/feature">>, "opaque"}
+    ]
+
+    version = commit!(proxy, epoch, mutations, "telemetry_key")
+
+    wait_until(fn -> proxy_metadata(proxy).version == version end)
+
+    metadata = proxy_metadata(proxy)
+    assert metadata.shards == %{"z" => 5}
+    refute Map.has_key?(metadata.shards, "/system/future/feature")
+
+    {measurements, meta} = expect_telemetry([:bedrock, :data_plane, :commit_proxy, :metadata_applied], 2_000)
+    assert measurements.count == 1
+    assert :shard_key in meta.families
+
+    {measurements, meta} = expect_telemetry([:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped], 2_000)
+    assert measurements.count == 1
+    assert meta.keys == [<<0xFF, "/system/future/feature">>]
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_test.exs
@@ -1,0 +1,210 @@
+defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+
+  defp v(n), do: Version.from_integer(n)
+
+  defp t2b(term), do: :erlang.term_to_binary(term)
+
+  defp apply!(metadata, updates) do
+    {metadata, _stats} = Metadata.apply_updates(metadata, updates)
+    metadata
+  end
+
+  describe "apply_updates/2 with sets" do
+    test "parses every key family PersistencePhase writes into its structured slot" do
+      mutations = [
+        {:set, SystemKeys.shard_key("m"), t2b(7)},
+        {:set, SystemKeys.shard(3), "raw-shard-metadata"},
+        {:set, SystemKeys.materializer_key("m"), "raw-materializers"},
+        {:set, SystemKeys.layout_log("log-1"), t2b([0, 1])},
+        {:set, SystemKeys.layout_services(), t2b(%{"log-1" => %{kind: :log}})},
+        {:set, SystemKeys.layout_id(), t2b("layout-abc")},
+        {:set, SystemKeys.cluster_coordinators(), t2b([:a@host])},
+        {:set, SystemKeys.cluster_epoch(), t2b(4)},
+        {:set, SystemKeys.cluster_policies_volunteer_nodes(), t2b(true)},
+        {:set, SystemKeys.cluster_parameters_desired_logs(), t2b(2)},
+        {:set, SystemKeys.cluster_parameters_desired_replication(), t2b(3)},
+        {:set, SystemKeys.cluster_parameters_desired_commit_proxies(), t2b(1)},
+        {:set, SystemKeys.cluster_parameters_desired_coordinators(), t2b(1)},
+        {:set, SystemKeys.cluster_parameters_desired_read_version_proxies(), t2b(1)},
+        {:set, SystemKeys.cluster_parameters_empty_transaction_timeout_ms(), t2b(1_000)},
+        {:set, SystemKeys.cluster_parameters_ping_rate_in_hz(), t2b(10)},
+        {:set, SystemKeys.cluster_parameters_retransmission_rate_in_hz(), t2b(5)},
+        {:set, SystemKeys.cluster_parameters_transaction_window_in_ms(), t2b(5_000)},
+        {:set, SystemKeys.recovery_attempt(), t2b(1)},
+        {:set, SystemKeys.recovery_state(), t2b(:completed)},
+        {:set, SystemKeys.recovery_last_completed(), t2b(123)},
+        {:set, SystemKeys.config_monolithic(), t2b({4, %{}})},
+        {:set, SystemKeys.epoch_legacy(), t2b(4)},
+        {:set, SystemKeys.last_recovery_legacy(), t2b(123)}
+      ]
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), mutations}])
+
+      assert metadata.version == v(1)
+      assert metadata.shards == %{"m" => 7}
+      # shard/materializer values are kept encoded (FlatBuffer / opaque)
+      assert metadata.shard_metadata == %{"3" => "raw-shard-metadata"}
+      assert metadata.materializers == %{"m" => "raw-materializers"}
+      assert metadata.logs == %{"log-1" => [0, 1]}
+      assert metadata.services == %{"log-1" => %{kind: :log}}
+      assert metadata.layout_id == "layout-abc"
+      assert metadata.cluster == %{coordinators: [:a@host], epoch: 4}
+      assert metadata.policies == %{volunteer_nodes: true}
+
+      assert metadata.parameters == %{
+               desired_logs: 2,
+               desired_replication: 3,
+               desired_commit_proxies: 1,
+               desired_coordinators: 1,
+               desired_read_version_proxies: 1,
+               empty_transaction_timeout_ms: 1_000,
+               ping_rate_in_hz: 10,
+               retransmission_rate_in_hz: 5,
+               transaction_window_in_ms: 5_000
+             }
+
+      assert metadata.recovery == %{attempt: 1, state: :completed, last_completed: 123}
+      assert metadata.legacy == %{config_monolithic: {4, %{}}, epoch_legacy: 4, last_recovery_legacy: 123}
+
+      assert stats.applied == length(mutations)
+      assert stats.skipped_keys == []
+
+      assert Enum.sort(stats.families) ==
+               Enum.sort([
+                 :shard_key,
+                 :shard,
+                 :materializer_key,
+                 :layout_log,
+                 :layout_services,
+                 :layout_id,
+                 :cluster,
+                 :cluster_policy,
+                 :cluster_parameter,
+                 :recovery,
+                 :legacy
+               ])
+    end
+
+    test "later version wins and version advances" do
+      metadata =
+        Metadata.new()
+        |> apply!([{v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}]}])
+        |> apply!([{v(2), [{:set, SystemKeys.shard_key("m"), t2b(9)}]}])
+
+      assert metadata.shards == %{"m" => 9}
+      assert metadata.version == v(2)
+    end
+
+    test "entries at or below the applied version are skipped (idempotent redelivery)" do
+      window = [
+        {v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}]},
+        {v(2), [{:set, SystemKeys.shard_key("m"), t2b(9)}]}
+      ]
+
+      metadata = apply!(Metadata.new(), window)
+
+      # Resolver re-sends the whole window (e.g. to a new finalization task)
+      {redelivered, stats} = Metadata.apply_updates(metadata, window)
+
+      assert redelivered == metadata
+      assert stats.applied == 0
+    end
+
+    test "within a version, later mutation wins" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}, {:set, SystemKeys.shard_key("m"), t2b(8)}]}
+        ])
+
+      assert metadata.shards == %{"m" => 8}
+    end
+  end
+
+  describe "apply_updates/2 with clears" do
+    test "clear removes the corresponding entry" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("m"), t2b(7)},
+             {:set, SystemKeys.layout_log("log-1"), t2b([0])},
+             {:set, SystemKeys.layout_id(), t2b("layout-abc")}
+           ]},
+          {v(2), [{:clear, SystemKeys.shard_key("m")}, {:clear, SystemKeys.layout_id()}]}
+        ])
+
+      assert metadata.shards == %{}
+      assert metadata.layout_id == nil
+      assert metadata.logs == %{"log-1" => [0]}
+    end
+
+    test "clear_range removes every known entry whose full key is in [start, end)" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("a"), t2b(1)},
+             {:set, SystemKeys.shard_key("m"), t2b(2)},
+             {:set, SystemKeys.shard_key("z"), t2b(3)},
+             {:set, SystemKeys.layout_log("log-1"), t2b([0])}
+           ]}
+        ])
+
+      {metadata, stats} =
+        Metadata.apply_updates(metadata, [
+          {v(2), [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}
+        ])
+
+      # Range end is exclusive: "a" and "m" cleared, "z" survives
+      assert metadata.shards == %{"z" => 3}
+      assert metadata.logs == %{"log-1" => [0]}
+      assert stats.applied == 1
+      assert stats.families == [:shard_key]
+    end
+  end
+
+  describe "apply_updates/2 forward compatibility" do
+    test "unknown system keys are ignored and counted" do
+      unknown_key = <<0xFF, "/system/future/feature">>
+      non_system_metadata_key = <<0xFF, "not-a-system-key">>
+
+      {metadata, stats} =
+        Metadata.apply_updates(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("m"), t2b(7)},
+             {:set, unknown_key, "opaque"},
+             {:clear, non_system_metadata_key}
+           ]}
+        ])
+
+      assert metadata.shards == %{"m" => 7}
+      assert stats.applied == 1
+      assert stats.skipped_keys == [unknown_key, non_system_metadata_key]
+    end
+
+    test "atomic mutations are not applied to structured metadata" do
+      key = SystemKeys.shard_key("m")
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:atomic, :add, key, <<1>>}]}])
+
+      assert metadata.shards == %{}
+      assert stats.applied == 0
+      assert stats.skipped_keys == [key]
+    end
+
+    test "unknown cluster parameters are ignored and counted" do
+      key = SystemKeys.system_prefix() <> "/cluster/parameters/future_knob"
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:set, key, t2b(1)}]}])
+
+      assert metadata.parameters == %{}
+      assert stats.skipped_keys == [key]
+    end
+  end
+end

--- a/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
@@ -1,0 +1,87 @@
+defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
+  @moduledoc """
+  Pins the resolver's metadata-window distribution semantics that the commit
+  proxy's ordering soundness currently depends on (bedrock-q67.15 gating audit).
+
+  ## Why this test exists
+
+  The commit proxy applies metadata windows in the SERVER process, but the
+  windows are *sent* from per-batch finalization tasks, so two batches' windows
+  can arrive at the server out of commit-version order (batch N+1's task can
+  win the race to the mailbox). `Metadata.apply_updates/2` drops any window
+  whose entries are all at or below the already-applied version.
+
+  Dropping an earlier-versioned window that arrives late is only lossless
+  because the resolver keys `proxy_progress` by the *caller* pid - and each
+  batch resolves from a fresh finalization task pid - so `last_seen` is always
+  nil and every reply carries the FULL retained window. Later windows are
+  therefore supersets of earlier ones, and applying the later one first already
+  includes everything the dropped earlier one carried.
+
+  If you make these windows truly differential (per-proxy identity, pruning),
+  this test will fail - which is the point: you must simultaneously give the
+  commit proxy in-order window application (or another gap-detection scheme),
+  otherwise the late-arriving earlier window is dropped and its mutations are
+  LOST from proxy metadata (fatal once the shard map rides this pipe, q67.9).
+  See bedrock-q67 / the metadata window protocol follow-up ticket.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+
+  defp encode_tx(key) do
+    Transaction.encode(%{
+      mutations: [{:set, key, "v"}],
+      read_conflicts: [],
+      write_conflicts: [{key, key <> <<0>>}]
+    })
+  end
+
+  # Resolve from a fresh pid, exactly like a commit proxy finalization task does
+  defp resolve_from_fresh_task(resolver, last_v, next_v, key, metadata) do
+    parent = self()
+
+    spawn_link(fn ->
+      result = Resolver.resolve_transactions(resolver, 1, last_v, next_v, [encode_tx(key)], [metadata])
+      send(parent, {:resolved, result})
+    end)
+
+    assert_receive {:resolved, result}, 2_000
+    result
+  end
+
+  test "windows returned to successive per-batch task pids are supersets (commit proxy ordering relies on this)" do
+    resolver =
+      start_supervised!(
+        {ResolverServer,
+         [
+           lock_token: :crypto.strong_rand_bytes(32),
+           key_range: {"", <<0xFF, 0xFF>>},
+           epoch: 1,
+           last_version: Version.zero(),
+           director: self(),
+           cluster: __MODULE__
+         ]}
+      )
+
+    v0 = Version.zero()
+    v1 = Version.from_integer(1)
+    v2 = Version.from_integer(2)
+
+    mutation1 = {:set, <<0xFF, "/system/shard_keys/a">>, :erlang.term_to_binary(1)}
+    mutation2 = {:set, <<0xFF, "/system/shard_keys/b">>, :erlang.term_to_binary(2)}
+
+    assert {:ok, [], window1} = resolve_from_fresh_task(resolver, v0, v1, "k1", [mutation1])
+    assert {:ok, [], window2} = resolve_from_fresh_task(resolver, v1, v2, "k2", [mutation2])
+
+    assert window1 == [{v1, [mutation1]}]
+
+    # The load-bearing invariant: the later batch's window contains everything
+    # the earlier batch's window did, so the commit proxy may safely drop an
+    # earlier window that loses the task->server mailbox race.
+    assert window2 == [{v1, [mutation1]}, {v2, [mutation2]}]
+  end
+end

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -239,6 +239,61 @@ defmodule Bedrock.SystemKeysTest do
         assert SystemKeys.parse_key(key) == {:materializer_key, end_key}
       end
     end
+
+    test "every fixed key family written by PersistencePhase round-trips" do
+      fixed_keys = [
+        {SystemKeys.layout_services(), :layout_services},
+        {SystemKeys.layout_id(), :layout_id},
+        {SystemKeys.cluster_coordinators(), {:cluster, :coordinators}},
+        {SystemKeys.cluster_epoch(), {:cluster, :epoch}},
+        {SystemKeys.cluster_policies_volunteer_nodes(), {:cluster_policy, :volunteer_nodes}},
+        {SystemKeys.cluster_parameters_desired_logs(), {:cluster_parameter, :desired_logs}},
+        {SystemKeys.cluster_parameters_desired_replication(), {:cluster_parameter, :desired_replication}},
+        {SystemKeys.cluster_parameters_desired_commit_proxies(), {:cluster_parameter, :desired_commit_proxies}},
+        {SystemKeys.cluster_parameters_desired_coordinators(), {:cluster_parameter, :desired_coordinators}},
+        {SystemKeys.cluster_parameters_desired_read_version_proxies(),
+         {:cluster_parameter, :desired_read_version_proxies}},
+        {SystemKeys.cluster_parameters_empty_transaction_timeout_ms(),
+         {:cluster_parameter, :empty_transaction_timeout_ms}},
+        {SystemKeys.cluster_parameters_ping_rate_in_hz(), {:cluster_parameter, :ping_rate_in_hz}},
+        {SystemKeys.cluster_parameters_retransmission_rate_in_hz(), {:cluster_parameter, :retransmission_rate_in_hz}},
+        {SystemKeys.cluster_parameters_transaction_window_in_ms(), {:cluster_parameter, :transaction_window_in_ms}},
+        {SystemKeys.recovery_attempt(), {:recovery, :attempt}},
+        {SystemKeys.recovery_state(), {:recovery, :state}},
+        {SystemKeys.recovery_last_completed(), {:recovery, :last_completed}},
+        {SystemKeys.config_monolithic(), :config_monolithic},
+        {SystemKeys.epoch_legacy(), :epoch_legacy},
+        {SystemKeys.last_recovery_legacy(), :last_recovery_legacy}
+      ]
+
+      for {key, expected} <- fixed_keys do
+        assert SystemKeys.parse_key(key) == expected,
+               "Expected #{inspect(key)} to parse as #{inspect(expected)}"
+      end
+    end
+
+    test "parse → generate inverse holds for parametrized families" do
+      # parse result carries everything needed to regenerate the exact key
+      key = SystemKeys.layout_log("log-xyz")
+      {:layout_log, id} = SystemKeys.parse_key(key)
+      assert SystemKeys.layout_log(id) == key
+
+      key = SystemKeys.shard_key("some-end-key")
+      {:shard_key, end_key} = SystemKeys.parse_key(key)
+      assert SystemKeys.shard_key(end_key) == key
+
+      key = SystemKeys.shard(42)
+      {:shard, tag} = SystemKeys.parse_key(key)
+      assert SystemKeys.shards_prefix() <> tag == key
+
+      key = SystemKeys.materializer_key("mat-end")
+      {:materializer_key, end_key} = SystemKeys.parse_key(key)
+      assert SystemKeys.materializer_key(end_key) == key
+    end
+
+    test "unknown cluster parameters parse as :unknown" do
+      assert SystemKeys.parse_key(SystemKeys.system_prefix() <> "/cluster/parameters/future_knob") == :unknown
+    end
   end
 
   describe "key consistency" do


### PR DESCRIPTION
## Summary

Proves and completes the `\xFF` system-metadata pipeline (Phase B critical-path prerequisite, bedrock-q67.15).

**What was actually broken vs already wired** (verifying the 2026-01 audit claim):
- Already wired since the audit: extraction of `\xFF` mutations at the proxy, resolver-side `MetadataAccumulator` (accumulate + differential windows + pruning), and routing-relevant families (`shard_key`, `layout_log`) applied into `RoutingData` during finalization.
- Still broken/missing (fixed here): the commit proxy kept **no** structured metadata state at all (`State` had no metadata field); there was no `metadata_merge_fn` seam — non-routing metadata updates from the resolver were silently discarded; `SystemKeys.parse_key/1` covered only 4 of the ~20 key families the director persists; no application telemetry.

## Changes

- `CommitProxy.Metadata` — new: reduces version-ordered resolver updates into a structured map mirroring `PersistencePhase` (shards, shard_metadata, materializers, logs, services, layout_id, cluster, policies, parameters, recovery, legacy). Documented semantics: idempotent version guard, later-value-wins, `{:clear, key}` deletes the entry, `{:clear_range, s, e}` deletes known entries with full key in `[s, e)`, unknown keys and atomics skipped + counted.
- `SystemKeys.parse_key/1` — extended to be the full inverse of the generators for every family `PersistencePhase` writes; round-trip tests both directions. (Kept the existing `parse_key/1` name rather than introducing `parse_system_key/1`; `RoutingData` already depends on it.)
- `Finalization` — `metadata_merge_fn` option (default no-op), invoked with the resolver's version-ordered updates at resolution time.
- `CommitProxy.Server` — supplies a real merge fn (sends updates back to the server process, which serializes application into typed `State.metadata`) and emits telemetry.
- Telemetry: `[:bedrock, :data_plane, :commit_proxy, :metadata_applied]` (count, families) and `[..., :unknown_key_skipped]` (count, keys).
- Key ENCODING untouched (`term_to_binary` stays; bedrock-ri40 follows).

## Integration test (the crown jewel)

`metadata_distribution_integration_test.exs`: real Sequencer.Server + real Resolver.Server + real CommitProxy.Server (only the log is faked). Written first; all 5 tests failed at the missing proxy-side wiring (`State` had no `:metadata`) before implementation. Covers: system-key mutation commit → resolver `MetadataAccumulator` capture → parsed structured entry in proxy state; ordered updates across two sequential batches (later value wins); non-system mutations never pollute metadata; multi-family parsing; unknown-key telemetry.

## Verification

- New tests at seeds 7 and 990011: 42 tests, 0 failures
- commit_proxy + resolver dirs at seeds 1 and 424242: 0 failures
- Full suite: 2647 tests, 0 failures
- `mix format`, `credo --strict` (no issues), `dialyzer` (0 errors)