### PR TITLE
Replace term_to_binary with explicit versioned encodings for system keys (bedrock-ri40)

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -37,6 +37,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
+  alias Bedrock.SystemKeys.Values
 
   require Logger
 
@@ -417,16 +418,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
     case Materializer.get_range(materializer_pid, prefix, end_key, read_version, limit: 1000) do
       {:ok, {entries, _more}} ->
-        shard_layout =
-          Map.new(entries, fn {key, value} ->
-            # Key format: \xff/system/shard_keys/<end_key>
-            # Value format: {tag, start_key}
-            end_key = extract_end_key_from_shard_key(key)
-            {tag, start_key} = decode_shard_value(value)
-            {end_key, {tag, start_key}}
-          end)
-
-        {:ok, shard_layout}
+        build_shard_layout(entries)
 
       {:error, reason} ->
         {:error, {:shard_layout_query_failed, reason}}
@@ -436,13 +428,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
+  # Key format: \xff/system/shard_keys/<end_key>
+  # Value format: {tag, start_key} (see Bedrock.SystemKeys.Values)
+  defp build_shard_layout(entries) do
+    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, shard_layout} ->
+      end_key = extract_end_key_from_shard_key(key)
+
+      case Values.decode_shard_key_entry(value) do
+        {:ok, {tag, start_key}} ->
+          {:cont, {:ok, Map.put(shard_layout, end_key, {tag, start_key})}}
+
+        {:error, reason} ->
+          {:halt, {:error, {:invalid_shard_value, key, reason}}}
+      end
+    end)
+  end
+
   defp extract_end_key_from_shard_key(key) do
     prefix = Bedrock.SystemKeys.shard_keys_prefix()
     prefix_len = byte_size(prefix)
     binary_part(key, prefix_len, byte_size(key) - prefix_len)
-  end
-
-  defp decode_shard_value(value) when is_binary(value) do
-    :erlang.binary_to_term(value)
   end
 end

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -33,6 +33,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.ClusterBootstrap
   alias Bedrock.SystemKeys.ShardMetadata
+  alias Bedrock.SystemKeys.Values
 
   @impl true
   def execute(recovery_attempt, context) do
@@ -206,11 +207,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   @spec build_monolithic_keys(Tx.t(), Bedrock.epoch(), map()) :: Tx.t()
   defp build_monolithic_keys(tx, epoch, encoded_config) do
     tx
-    |> Tx.set(SystemKeys.config_monolithic(), :erlang.term_to_binary({epoch, encoded_config}))
-    |> Tx.set(SystemKeys.epoch_legacy(), :erlang.term_to_binary(epoch))
+    |> Tx.set(SystemKeys.config_monolithic(), Values.encode_structured({epoch, encoded_config}))
+    |> Tx.set(SystemKeys.epoch_legacy(), Values.encode_integer(epoch))
     |> Tx.set(
       SystemKeys.last_recovery_legacy(),
-      :erlang.term_to_binary(System.system_time(:millisecond))
+      Values.encode_integer(System.system_time(:millisecond))
     )
   end
 
@@ -229,83 +230,82 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       tx
       |> Tx.set(
         SystemKeys.cluster_coordinators(),
-        :erlang.term_to_binary(cluster_config.coordinators)
+        Values.encode_node_list(cluster_config.coordinators)
       )
-      |> Tx.set(SystemKeys.cluster_epoch(), :erlang.term_to_binary(epoch))
+      |> Tx.set(SystemKeys.cluster_epoch(), Values.encode_integer(epoch))
       |> Tx.set(
         SystemKeys.cluster_policies_volunteer_nodes(),
-        :erlang.term_to_binary(cluster_config.policies.allow_volunteer_nodes_to_join)
+        Values.encode_boolean(cluster_config.policies.allow_volunteer_nodes_to_join || false)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_logs(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_logs)
+        Values.encode_integer(cluster_config.parameters.desired_logs)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_replication(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_replication_factor)
+        Values.encode_integer(cluster_config.parameters.desired_replication_factor)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_commit_proxies(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_commit_proxies)
+        Values.encode_integer(cluster_config.parameters.desired_commit_proxies)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_coordinators(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_coordinators)
+        Values.encode_integer(cluster_config.parameters.desired_coordinators)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_read_version_proxies(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_read_version_proxies)
+        Values.encode_integer(cluster_config.parameters.desired_read_version_proxies)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_empty_transaction_timeout_ms(),
-        :erlang.term_to_binary(Map.get(cluster_config.parameters, :empty_transaction_timeout_ms, 1_000))
+        Values.encode_integer(Map.get(cluster_config.parameters, :empty_transaction_timeout_ms, 1_000))
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_ping_rate_in_hz(),
-        :erlang.term_to_binary(cluster_config.parameters.ping_rate_in_hz)
+        Values.encode_integer(cluster_config.parameters.ping_rate_in_hz)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_retransmission_rate_in_hz(),
-        :erlang.term_to_binary(cluster_config.parameters.retransmission_rate_in_hz)
+        Values.encode_integer(cluster_config.parameters.retransmission_rate_in_hz)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_transaction_window_in_ms(),
-        :erlang.term_to_binary(cluster_config.parameters.transaction_window_in_ms)
+        Values.encode_integer(cluster_config.parameters.transaction_window_in_ms)
       )
 
     # Only durable layout config (services and id)
     tx =
       tx
-      |> Tx.set(SystemKeys.layout_services(), :erlang.term_to_binary(encoded_services))
-      |> Tx.set(SystemKeys.layout_id(), :erlang.term_to_binary(transaction_system_layout.id))
+      |> Tx.set(SystemKeys.layout_services(), Values.encode_structured(encoded_services))
+      |> Tx.set(SystemKeys.layout_id(), Values.encode_id(transaction_system_layout.id))
 
     tx =
       Enum.reduce(transaction_system_layout.logs, tx, fn {log_id, log_descriptor}, tx ->
-        encoded_descriptor =
-          log_descriptor
-          |> encode_log_descriptor_for_storage()
-          |> :erlang.term_to_binary()
-
-        Tx.set(tx, SystemKeys.layout_log(log_id), encoded_descriptor)
+        Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
       end)
 
     # Shard keys use ceiling-search pattern
     tx = build_shard_keys(tx, transaction_system_layout.shard_layout)
 
     tx
-    |> Tx.set(SystemKeys.recovery_attempt(), :erlang.term_to_binary(1))
+    |> Tx.set(SystemKeys.recovery_attempt(), Values.encode_integer(1))
     |> Tx.set(
       SystemKeys.recovery_last_completed(),
-      :millisecond |> System.system_time() |> :erlang.term_to_binary()
+      Values.encode_integer(System.system_time(:millisecond))
     )
   end
 
-  defp encode_services_for_storage(services) when is_map(services), do: services
-
-  @spec encode_log_descriptor_for_storage([term()]) :: [term()]
-  defp encode_log_descriptor_for_storage(log_descriptor) do
-    # Log descriptors typically don't contain PIDs directly
-    log_descriptor
+  # Runtime PIDs are meaningless in durable storage: a later epoch cannot use
+  # them, so live statuses are stored as :unknown. Service refs are
+  # re-populated at runtime by the director.
+  defp encode_services_for_storage(services) when is_map(services) do
+    Map.new(services, fn {service_id, descriptor} ->
+      case descriptor do
+        %{status: {:up, pid}} when is_pid(pid) -> {service_id, %{descriptor | status: :unknown}}
+        _ -> {service_id, descriptor}
+      end
+    end)
   end
 
   # Creates shard_key(end_key) -> tag and shard(tag) -> ShardMetadata entries
@@ -316,8 +316,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
 
   defp build_shard_keys(tx, shard_layout) when is_map(shard_layout) do
     Enum.reduce(shard_layout, tx, fn {end_key, {tag, start_key}}, tx ->
-      # Write shard_key(end_key) -> tag (for ceiling search)
-      tx = Tx.set(tx, SystemKeys.shard_key(end_key), :erlang.term_to_binary(tag))
+      # Write shard_key(end_key) -> {tag, start_key} (for ceiling search)
+      tx = Tx.set(tx, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key))
 
       # Write shard(tag) -> ShardMetadata (FlatBuffer encoded)
       # born_at is 0 for now - will be set properly once we track shard versions

--- a/lib/bedrock/data_plane/commit_proxy/metadata.ex
+++ b/lib/bedrock/data_plane/commit_proxy/metadata.ex
@@ -14,7 +14,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
   - `version` - highest commit version applied so far (nil until first update)
   - `shards` - `shard_key(end_key) -> tag` ceiling-search shard map
   - `shard_metadata` - `shard(tag) -> encoded ShardMetadata` (kept encoded;
-    FlatBuffer, not `term_to_binary`)
+    FlatBuffer)
   - `materializers` - `materializer_key(end_key) -> encoded value` (kept encoded)
   - `logs` - `layout_log(log_id) -> decoded log descriptor`
   - `services` - decoded `layout_services` map
@@ -38,11 +38,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
   - `{:clear_range, start_key, end_key}` - removes every known entry whose full
     system key falls within `[start_key, end_key)`
   - Unknown or unparseable system keys are ignored (forward compatibility) and
-    counted in the returned stats; the same goes for `{:atomic, ...}` mutations,
+    counted in the returned stats; the same goes for values that fail to
+    decode (see `Bedrock.SystemKeys.Values`) and `{:atomic, ...}` mutations,
     which are not supported for structured metadata.
   """
 
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   @type family ::
           :shard_key
@@ -124,9 +126,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
   # ============================================================================
 
   defp apply_mutation({:set, key, value}, {metadata, stats}) do
-    case SystemKeys.parse_key(key) do
-      parsed when parsed in [:unknown, :error] -> skip(key, {metadata, stats})
-      parsed -> applied(family_of(parsed), {put_entry(metadata, parsed, value), stats})
+    with parsed when parsed not in [:unknown, :error] <- SystemKeys.parse_key(key),
+         {:ok, decoded} <- Values.decode_for(parsed, value) do
+      applied(family_of(parsed), {put_entry(metadata, parsed, decoded), stats})
+    else
+      _ -> skip(key, {metadata, stats})
     end
   end
 
@@ -167,11 +171,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
   # Entry storage (parsed key -> struct slot)
   # ============================================================================
 
-  # Values written by PersistencePhase are term_to_binary encoded, except
+  # Values arrive decoded per family by Bedrock.SystemKeys.Values, except
   # shard/1 (FlatBuffer ShardMetadata) and materializer_key/1, which are kept
-  # encoded. Encoding will change under bedrock-ri40; decode stays centralized here.
-  defp put_entry(metadata, {:shard_key, end_key}, value),
-    do: %{metadata | shards: Map.put(metadata.shards, end_key, decode(value))}
+  # encoded. A shard_key value decodes to {tag, start_key}; only the tag is
+  # kept, since the shards slot is the ceiling-search routing view.
+  defp put_entry(metadata, {:shard_key, end_key}, {tag, _start_key}),
+    do: %{metadata | shards: Map.put(metadata.shards, end_key, tag)}
 
   defp put_entry(metadata, {:shard, tag}, value),
     do: %{metadata | shard_metadata: Map.put(metadata.shard_metadata, tag, value)}
@@ -179,26 +184,24 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
   defp put_entry(metadata, {:materializer_key, end_key}, value),
     do: %{metadata | materializers: Map.put(metadata.materializers, end_key, value)}
 
-  defp put_entry(metadata, {:layout_log, log_id}, value),
-    do: %{metadata | logs: Map.put(metadata.logs, log_id, decode(value))}
+  defp put_entry(metadata, {:layout_log, log_id}, value), do: %{metadata | logs: Map.put(metadata.logs, log_id, value)}
 
-  defp put_entry(metadata, :layout_services, value), do: %{metadata | services: decode(value)}
-  defp put_entry(metadata, :layout_id, value), do: %{metadata | layout_id: decode(value)}
+  defp put_entry(metadata, :layout_services, value), do: %{metadata | services: value}
+  defp put_entry(metadata, :layout_id, value), do: %{metadata | layout_id: value}
 
-  defp put_entry(metadata, {:cluster, name}, value),
-    do: %{metadata | cluster: Map.put(metadata.cluster, name, decode(value))}
+  defp put_entry(metadata, {:cluster, name}, value), do: %{metadata | cluster: Map.put(metadata.cluster, name, value)}
 
   defp put_entry(metadata, {:cluster_policy, name}, value),
-    do: %{metadata | policies: Map.put(metadata.policies, name, decode(value))}
+    do: %{metadata | policies: Map.put(metadata.policies, name, value)}
 
   defp put_entry(metadata, {:cluster_parameter, name}, value),
-    do: %{metadata | parameters: Map.put(metadata.parameters, name, decode(value))}
+    do: %{metadata | parameters: Map.put(metadata.parameters, name, value)}
 
   defp put_entry(metadata, {:recovery, name}, value),
-    do: %{metadata | recovery: Map.put(metadata.recovery, name, decode(value))}
+    do: %{metadata | recovery: Map.put(metadata.recovery, name, value)}
 
   defp put_entry(metadata, legacy, value) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
-    do: %{metadata | legacy: Map.put(metadata.legacy, legacy, decode(value))}
+    do: %{metadata | legacy: Map.put(metadata.legacy, legacy, value)}
 
   defp delete_entry(metadata, {:shard_key, end_key}), do: %{metadata | shards: Map.delete(metadata.shards, end_key)}
 
@@ -220,8 +223,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Metadata do
 
   defp delete_entry(metadata, legacy) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
     do: %{metadata | legacy: Map.delete(metadata.legacy, legacy)}
-
-  defp decode(value), do: :erlang.binary_to_term(value)
 
   # ============================================================================
   # clear_range support: enumerate every stored entry with its full system key

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -29,6 +29,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   alias Bedrock.DataPlane.Log
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   @type t :: %__MODULE__{
           shard_table: :ets.table(),
@@ -165,14 +166,18 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   defp apply_mutation({:set, key, value}, routing_data) do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
-        tag = :erlang.binary_to_term(value)
-        insert_shard(routing_data, end_key, tag)
+        # Undecodable values are ignored; the routing table keeps its last
+        # good entry rather than crashing the commit proxy.
+        case Values.decode_shard_key_entry(value) do
+          {:ok, {tag, _start_key}} -> insert_shard(routing_data, end_key, tag)
+          {:error, _} -> :ignored
+        end
+
         routing_data
 
       {:layout_log, log_id} ->
-        # layout_log stores the log descriptor (tags) as erlang term, not OtpRef
-        # Service refs are populated at runtime by the director, not from persisted data
-        _log_descriptor = :erlang.binary_to_term(value)
+        # The value (log descriptor tags) is not needed for routing; service
+        # refs are populated at runtime by the director, not from persisted data.
         insert_log(routing_data, log_id)
 
       _ ->

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -1,0 +1,322 @@
+defmodule Bedrock.SystemKeys.Values do
+  @moduledoc """
+  Explicit value encodings for the `\\xFF/system` keyspace.
+
+  Every system-key value family gets a deliberate encoding instead of
+  `:erlang.term_to_binary/1`, which is BEAM-only and unsafe to decode from
+  durable storage. Encoders are used by trusted writers (the director's
+  recovery persistence phase) and raise on invalid input; decoders never
+  raise -- they return `{:ok, value}` or `{:error, reason}` so consumers can
+  skip malformed values.
+
+  ## Encodings by family
+
+  Simple scalar families use `Bedrock.Encoding.Tuple` (FDB tuple encoding:
+  self-describing type tags, language-neutral, order-preserving). The key
+  itself identifies the family, so no extra version byte is carried:
+
+    * integers -- epochs, cluster parameters, timestamps, recovery attempt
+    * booleans -- cluster policies (encoded as integer 0/1)
+    * atoms -- recovery state (encoded as string)
+    * ids -- layout id (integer or binary)
+    * node lists -- cluster coordinators (encoded as strings)
+    * tag lists -- log descriptors (lists of range tags)
+    * shard key entries -- `{tag, start_key}` tuples
+
+  Structured families (`config_monolithic`, `layout_services`) hold nested
+  maps/tuples with atoms, so they use a versioned explicit term encoding
+  (leading version byte, currently `0x01`). The codec supports exactly nil,
+  booleans, atoms, binaries, 64-bit integers, floats, tuples, lists, and
+  maps; PIDs, refs, and funs are rejected at encode time -- writers must
+  sanitize runtime references first.
+
+  FlatBuffer families (`shard/1` -> `Bedrock.SystemKeys.ShardMetadata`,
+  `materializer_key/1` -> `Bedrock.SystemKeys.MaterializerList`) are already
+  explicitly encoded and are passed through opaque here.
+
+  Atoms are re-created with `String.to_atom/1` on decode. The `\\xFF`
+  keyspace is only writable by privileged control-plane components, and the
+  atom population (config field names, service kinds, node names) is bounded
+  by cluster configuration.
+  """
+
+  import Bitwise, only: [<<<: 2]
+
+  alias Bedrock.Encoding.Tuple, as: TupleEncoding
+
+  @structured_version 0x01
+
+  @typedoc "A parsed system key, as returned by `Bedrock.SystemKeys.parse_key/1`"
+  @type parsed_key ::
+          {:layout_log, String.t()}
+          | {:shard_key, String.t()}
+          | {:shard, String.t()}
+          | {:materializer_key, String.t()}
+          | :layout_services
+          | :layout_id
+          | {:cluster, :coordinators | :epoch}
+          | {:cluster_policy, :volunteer_nodes}
+          | {:cluster_parameter, atom()}
+          | {:recovery, :attempt | :state | :last_completed}
+          | :config_monolithic
+          | :epoch_legacy
+          | :last_recovery_legacy
+
+  @type decode_error :: {:error, :invalid_encoding | :invalid_type | :unsupported_version | :unknown_family}
+
+  # ============================================================================
+  # Encoders (trusted writers; raise on invalid input)
+  # ============================================================================
+
+  @doc "Encodes an integer (epoch, parameter, timestamp, recovery attempt)."
+  @spec encode_integer(integer()) :: binary()
+  def encode_integer(i) when is_integer(i), do: TupleEncoding.pack(i)
+
+  @doc "Encodes a boolean policy value as integer 0/1."
+  @spec encode_boolean(boolean()) :: binary()
+  def encode_boolean(true), do: TupleEncoding.pack(1)
+  def encode_boolean(false), do: TupleEncoding.pack(0)
+
+  @doc "Encodes an atom as its string representation."
+  @spec encode_atom(atom()) :: binary()
+  def encode_atom(a) when is_atom(a), do: TupleEncoding.pack(Atom.to_string(a))
+
+  @doc "Encodes a layout id (integer or binary)."
+  @spec encode_id(integer() | binary()) :: binary()
+  def encode_id(id) when is_integer(id) or is_binary(id), do: TupleEncoding.pack(id)
+
+  @doc "Encodes a list of node atoms as strings (cluster coordinators)."
+  @spec encode_node_list([node()]) :: binary()
+  def encode_node_list(nodes) when is_list(nodes), do: TupleEncoding.pack(Enum.map(nodes, &Atom.to_string/1))
+
+  @doc "Encodes a list of integer range tags (log descriptor)."
+  @spec encode_tag_list([Bedrock.range_tag()]) :: binary()
+  def encode_tag_list(tags) when is_list(tags) do
+    if Enum.all?(tags, &is_integer/1) do
+      TupleEncoding.pack(tags)
+    else
+      raise ArgumentError, "tag list must contain only integers: #{inspect(tags)}"
+    end
+  end
+
+  @doc """
+  Encodes a shard key entry: `{tag, start_key}`.
+
+  The key carries the shard's `end_key`; the value carries the tag and the
+  range's start key so readers (materializer bootstrap) can reconstruct the
+  full shard layout without relying on adjacency.
+  """
+  @spec encode_shard_key_entry(Bedrock.range_tag(), Bedrock.key()) :: binary()
+  def encode_shard_key_entry(tag, start_key) when is_integer(tag) and is_binary(start_key),
+    do: TupleEncoding.pack({tag, start_key})
+
+  @doc """
+  Encodes a structured term (`config_monolithic`, `layout_services`) with a
+  leading version byte.
+
+  Supports nil, booleans, atoms, binaries, 64-bit integers, floats, tuples,
+  lists, and maps. Raises `ArgumentError` for anything else (PIDs, refs,
+  funs) -- writers must sanitize runtime references first.
+  """
+  @spec encode_structured(term()) :: binary()
+  def encode_structured(term), do: IO.iodata_to_binary([@structured_version | encode_term(term)])
+
+  # ============================================================================
+  # Decoders (never raise)
+  # ============================================================================
+
+  @doc "Decodes an integer value."
+  @spec decode_integer(binary()) :: {:ok, integer()} | decode_error()
+  def decode_integer(binary), do: safe_unpack(binary, &is_integer/1)
+
+  @doc "Decodes a boolean policy value."
+  @spec decode_boolean(binary()) :: {:ok, boolean()} | decode_error()
+  def decode_boolean(binary) do
+    case safe_unpack(binary, &(&1 in [0, 1])) do
+      {:ok, 1} -> {:ok, true}
+      {:ok, 0} -> {:ok, false}
+      error -> error
+    end
+  end
+
+  @doc "Decodes an atom value."
+  @spec decode_atom(binary()) :: {:ok, atom()} | decode_error()
+  def decode_atom(binary) do
+    with {:ok, string} <- safe_unpack(binary, &is_binary/1) do
+      {:ok, String.to_atom(string)}
+    end
+  end
+
+  @doc "Decodes a layout id (integer or binary)."
+  @spec decode_id(binary()) :: {:ok, integer() | binary()} | decode_error()
+  def decode_id(binary), do: safe_unpack(binary, &(is_integer(&1) or is_binary(&1)))
+
+  @doc "Decodes a list of node atoms."
+  @spec decode_node_list(binary()) :: {:ok, [node()]} | decode_error()
+  def decode_node_list(binary) do
+    with {:ok, strings} <- safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn s -> is_binary(s) end))) do
+      {:ok, Enum.map(strings, &String.to_atom/1)}
+    end
+  end
+
+  @doc "Decodes a list of integer range tags."
+  @spec decode_tag_list(binary()) :: {:ok, [Bedrock.range_tag()]} | decode_error()
+  def decode_tag_list(binary), do: safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn t -> is_integer(t) end)))
+
+  @doc "Decodes a shard key entry to `{:ok, {tag, start_key}}`."
+  @spec decode_shard_key_entry(binary()) :: {:ok, {Bedrock.range_tag(), Bedrock.key()}} | decode_error()
+  def decode_shard_key_entry(binary),
+    do: safe_unpack(binary, &match?({tag, start_key} when is_integer(tag) and is_binary(start_key), &1))
+
+  @doc "Decodes a versioned structured term."
+  @spec decode_structured(binary()) :: {:ok, term()} | decode_error()
+  def decode_structured(<<@structured_version, payload::binary>>) do
+    case decode_term(payload) do
+      {:ok, term, <<>>} -> {:ok, term}
+      _ -> {:error, :invalid_encoding}
+    end
+  end
+
+  def decode_structured(<<_version, _rest::binary>>), do: {:error, :unsupported_version}
+  def decode_structured(_), do: {:error, :invalid_encoding}
+
+  @doc """
+  Decodes a value given its parsed system key (from
+  `Bedrock.SystemKeys.parse_key/1`).
+
+  FlatBuffer families (`{:shard, tag}` and `{:materializer_key, end_key}`)
+  are returned opaque -- their consumers decode them with the appropriate
+  schema module.
+  """
+  @spec decode_for(parsed_key(), binary()) :: {:ok, term()} | decode_error()
+  def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
+  def decode_for({:shard, _tag}, value), do: {:ok, value}
+  def decode_for({:materializer_key, _end_key}, value), do: {:ok, value}
+  def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
+  def decode_for(:layout_services, value), do: decode_structured(value)
+  def decode_for(:layout_id, value), do: decode_id(value)
+  def decode_for({:cluster, :coordinators}, value), do: decode_node_list(value)
+  def decode_for({:cluster, :epoch}, value), do: decode_integer(value)
+  def decode_for({:cluster_policy, _name}, value), do: decode_boolean(value)
+  def decode_for({:cluster_parameter, _name}, value), do: decode_integer(value)
+  def decode_for({:recovery, :state}, value), do: decode_atom(value)
+  def decode_for({:recovery, _name}, value), do: decode_integer(value)
+  def decode_for(:config_monolithic, value), do: decode_structured(value)
+  def decode_for(:epoch_legacy, value), do: decode_integer(value)
+  def decode_for(:last_recovery_legacy, value), do: decode_integer(value)
+  # Defensive catch-all: a key family added to SystemKeys.parse_key/1 without
+  # a matching decoder must degrade to a skipped value, not a crash.
+  def decode_for(_parsed, _value), do: {:error, :unknown_family}
+
+  # ============================================================================
+  # Tuple-encoding safety wrapper
+  # ============================================================================
+
+  @spec safe_unpack(binary(), (term() -> boolean())) :: {:ok, term()} | decode_error()
+  defp safe_unpack(binary, valid?) when is_binary(binary) do
+    value = TupleEncoding.unpack(binary)
+
+    if valid?.(value) do
+      {:ok, value}
+    else
+      {:error, :invalid_type}
+    end
+  rescue
+    _ -> {:error, :invalid_encoding}
+  end
+
+  defp safe_unpack(_not_binary, _valid?), do: {:error, :invalid_encoding}
+
+  # ============================================================================
+  # Versioned structured term codec (v1)
+  # ============================================================================
+
+  @t_nil 0x00
+  @t_true 0x01
+  @t_false 0x02
+  @t_atom 0x03
+  @t_binary 0x04
+  @t_int 0x05
+  @t_float 0x06
+  @t_tuple 0x07
+  @t_list 0x08
+  @t_map 0x09
+
+  @int_min -(1 <<< 63)
+  @int_max (1 <<< 63) - 1
+
+  @spec encode_term(term()) :: iodata()
+  defp encode_term(nil), do: <<@t_nil>>
+  defp encode_term(true), do: <<@t_true>>
+  defp encode_term(false), do: <<@t_false>>
+
+  defp encode_term(atom) when is_atom(atom) do
+    string = Atom.to_string(atom)
+    [<<@t_atom, byte_size(string)::16>>, string]
+  end
+
+  defp encode_term(binary) when is_binary(binary), do: [<<@t_binary, byte_size(binary)::32>>, binary]
+
+  defp encode_term(int) when is_integer(int) and int >= @int_min and int <= @int_max, do: <<@t_int, int::signed-64>>
+
+  defp encode_term(float) when is_float(float), do: <<@t_float, float::float-64>>
+
+  defp encode_term(tuple) when is_tuple(tuple) do
+    elements = Tuple.to_list(tuple)
+    [<<@t_tuple, length(elements)::16>> | Enum.map(elements, &encode_term/1)]
+  end
+
+  defp encode_term(list) when is_list(list), do: [<<@t_list, length(list)::32>> | Enum.map(list, &encode_term/1)]
+
+  defp encode_term(map) when is_map(map) and not is_struct(map) do
+    pairs = Enum.sort(Map.to_list(map))
+    [<<@t_map, length(pairs)::32>> | Enum.map(pairs, fn {k, v} -> [encode_term(k), encode_term(v)] end)]
+  end
+
+  defp encode_term(unsupported) do
+    raise ArgumentError, "unsupported term in structured system-key value: #{inspect(unsupported)}"
+  end
+
+  @spec decode_term(binary()) :: {:ok, term(), binary()} | :error
+  defp decode_term(<<@t_nil, rest::binary>>), do: {:ok, nil, rest}
+  defp decode_term(<<@t_true, rest::binary>>), do: {:ok, true, rest}
+  defp decode_term(<<@t_false, rest::binary>>), do: {:ok, false, rest}
+
+  defp decode_term(<<@t_atom, size::16, string::binary-size(size), rest::binary>>),
+    do: {:ok, String.to_atom(string), rest}
+
+  defp decode_term(<<@t_binary, size::32, binary::binary-size(size), rest::binary>>), do: {:ok, binary, rest}
+  defp decode_term(<<@t_int, int::signed-64, rest::binary>>), do: {:ok, int, rest}
+  defp decode_term(<<@t_float, float::float-64, rest::binary>>), do: {:ok, float, rest}
+
+  defp decode_term(<<@t_tuple, count::16, rest::binary>>) do
+    with {:ok, elements, rest} <- decode_terms(rest, count, []) do
+      {:ok, List.to_tuple(elements), rest}
+    end
+  end
+
+  defp decode_term(<<@t_list, count::32, rest::binary>>), do: decode_terms(rest, count, [])
+
+  defp decode_term(<<@t_map, count::32, rest::binary>>), do: decode_map_pairs(rest, count, %{})
+
+  defp decode_term(_), do: :error
+
+  @spec decode_terms(binary(), non_neg_integer(), [term()]) :: {:ok, [term()], binary()} | :error
+  defp decode_terms(rest, 0, acc), do: {:ok, Enum.reverse(acc), rest}
+
+  defp decode_terms(binary, count, acc) do
+    with {:ok, term, rest} <- decode_term(binary) do
+      decode_terms(rest, count - 1, [term | acc])
+    end
+  end
+
+  @spec decode_map_pairs(binary(), non_neg_integer(), map()) :: {:ok, map(), binary()} | :error
+  defp decode_map_pairs(rest, 0, acc), do: {:ok, acc, rest}
+
+  defp decode_map_pairs(binary, count, acc) do
+    with {:ok, key, rest} <- decode_term(binary),
+         {:ok, value, rest} <- decode_term(rest) do
+      decode_map_pairs(rest, count - 1, Map.put(acc, key, value))
+    end
+  end
+end

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -34,10 +34,12 @@ defmodule Bedrock.SystemKeys.Values do
   `materializer_key/1` -> `Bedrock.SystemKeys.MaterializerList`) are already
   explicitly encoded and are passed through opaque here.
 
-  Atoms are re-created with `String.to_atom/1` on decode. The `\\xFF`
-  keyspace is only writable by privileged control-plane components, and the
-  atom population (config field names, service kinds, node names) is bounded
-  by cluster configuration.
+  Atoms are re-created with `String.to_existing_atom/1` on decode; a string
+  that does not name an existing atom is a decode error (`{:error,
+  :unknown_atom}`), never a new atom -- durable bytes must not be able to
+  grow the atom table. The legitimate atom population (config field names,
+  service kinds, node names) already exists on any node that consumes these
+  values.
   """
 
   import Bitwise, only: [<<<: 2]
@@ -62,7 +64,8 @@ defmodule Bedrock.SystemKeys.Values do
           | :epoch_legacy
           | :last_recovery_legacy
 
-  @type decode_error :: {:error, :invalid_encoding | :invalid_type | :unsupported_version | :unknown_family}
+  @type decode_error ::
+          {:error, :invalid_encoding | :invalid_type | :unknown_atom | :unsupported_version | :unknown_family}
 
   # ============================================================================
   # Encoders (trusted writers; raise on invalid input)
@@ -143,7 +146,7 @@ defmodule Bedrock.SystemKeys.Values do
   @spec decode_atom(binary()) :: {:ok, atom()} | decode_error()
   def decode_atom(binary) do
     with {:ok, string} <- safe_unpack(binary, &is_binary/1) do
-      {:ok, String.to_atom(string)}
+      existing_atom(string)
     end
   end
 
@@ -155,7 +158,17 @@ defmodule Bedrock.SystemKeys.Values do
   @spec decode_node_list(binary()) :: {:ok, [node()]} | decode_error()
   def decode_node_list(binary) do
     with {:ok, strings} <- safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn s -> is_binary(s) end))) do
-      {:ok, Enum.map(strings, &String.to_atom/1)}
+      strings
+      |> Enum.reduce_while({:ok, []}, fn string, {:ok, acc} ->
+        case existing_atom(string) do
+          {:ok, node} -> {:cont, {:ok, [node | acc]}}
+          error -> {:halt, error}
+        end
+      end)
+      |> case do
+        {:ok, nodes} -> {:ok, Enum.reverse(nodes)}
+        error -> error
+      end
     end
   end
 
@@ -227,6 +240,15 @@ defmodule Bedrock.SystemKeys.Values do
 
   defp safe_unpack(_not_binary, _valid?), do: {:error, :invalid_encoding}
 
+  # Decoding durable bytes must never create atoms: only strings naming
+  # atoms that already exist on this node are accepted.
+  @spec existing_atom(String.t()) :: {:ok, atom()} | {:error, :unknown_atom}
+  defp existing_atom(string) do
+    {:ok, String.to_existing_atom(string)}
+  rescue
+    ArgumentError -> {:error, :unknown_atom}
+  end
+
   # ============================================================================
   # Versioned structured term codec (v1)
   # ============================================================================
@@ -282,8 +304,12 @@ defmodule Bedrock.SystemKeys.Values do
   defp decode_term(<<@t_true, rest::binary>>), do: {:ok, true, rest}
   defp decode_term(<<@t_false, rest::binary>>), do: {:ok, false, rest}
 
-  defp decode_term(<<@t_atom, size::16, string::binary-size(size), rest::binary>>),
-    do: {:ok, String.to_atom(string), rest}
+  defp decode_term(<<@t_atom, size::16, string::binary-size(size), rest::binary>>) do
+    case existing_atom(string) do
+      {:ok, atom} -> {:ok, atom, rest}
+      {:error, _} -> :error
+    end
+  end
 
   defp decode_term(<<@t_binary, size::32, binary::binary-size(size), rest::binary>>), do: {:ok, binary, rest}
   defp decode_term(<<@t_int, int::signed-64, rest::binary>>), do: {:ok, int, rest}

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -4,6 +4,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   # Shared test data setup
   defp mock_transaction_system_layout do
@@ -59,6 +62,46 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # Pattern match tuple destructuring with expected stall reason
       assert {_, {:stalled, {:recovery_system_failed, :timeout}}} =
                PersistencePhase.execute(recovery_attempt, context)
+    end
+
+    test "every system-key value it writes decodes through Values.decode_for/2" do
+      recovery_attempt = base_recovery_attempt()
+      test_pid = self()
+
+      commit_fn = fn _proxy, _epoch, encoded_transaction ->
+        send(test_pid, {:committed, encoded_transaction})
+        {:ok, 1, 0}
+      end
+
+      context = Map.put(recovery_context(), :commit_transaction_fn, commit_fn)
+      assert {_, :completed} = PersistencePhase.execute(recovery_attempt, context)
+      assert_received {:committed, encoded_transaction}
+
+      sets =
+        encoded_transaction
+        |> Transaction.mutations!()
+        |> Enum.map(fn {:set, key, value} -> {key, value} end)
+
+      refute sets == []
+
+      # Every written value must decode via the family dispatched from its key;
+      # this is the writer/reader contract that masked the pre-fix shard_key bug.
+      decoded =
+        Map.new(sets, fn {key, value} ->
+          parsed = SystemKeys.parse_key(key)
+          refute parsed in [:unknown, :error], "wrote unparseable system key: #{inspect(key)}"
+          assert {:ok, decoded} = Values.decode_for(parsed, value), "value for #{inspect(key)} failed to decode"
+          {parsed, decoded}
+        end)
+
+      # Shard keys must decode to the exact {tag, start_key} the layout holds --
+      # the shape the materializer bootstrap cross-epoch read depends on.
+      assert decoded[{:shard_key, <<0xFF>>}] == {1, <<>>}
+      assert decoded[{:shard_key, <<0xFF, 0xFF>>}] == {0, <<0xFF>>}
+
+      # Services are sanitized: no live pid survives into durable storage.
+      assert %{"log_1" => %{status: :unknown}} = decoded[:layout_services]
+      assert decoded[{:layout_log, "log_1"}] == [1, 2]
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -25,6 +25,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   defmodule TestCluster do
     @moduledoc false
@@ -151,7 +152,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     epoch: epoch
   } do
     shard_key = SystemKeys.shard_key("m")
-    encoded_tag = :erlang.term_to_binary(7)
+    encoded_tag = Values.encode_shard_key_entry(7, "")
 
     version =
       commit!(
@@ -178,10 +179,10 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
   } do
     shard_key = SystemKeys.shard_key("m")
 
-    _v1 = commit!(proxy, epoch, [{:set, shard_key, :erlang.term_to_binary(7)}], "key_a")
+    _v1 = commit!(proxy, epoch, [{:set, shard_key, Values.encode_shard_key_entry(7, "")}], "key_a")
     wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 7} end)
 
-    v2 = commit!(proxy, epoch, [{:set, shard_key, :erlang.term_to_binary(9)}], "key_b")
+    v2 = commit!(proxy, epoch, [{:set, shard_key, Values.encode_shard_key_entry(9, "")}], "key_b")
     wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 9} end)
 
     assert %Metadata{shards: %{"m" => 9}, version: ^v2} = proxy_metadata(proxy)
@@ -199,12 +200,12 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
 
   test "multiple key families parse into their structured slots", %{proxy: proxy, epoch: epoch} do
     mutations = [
-      {:set, SystemKeys.shard_key("g"), :erlang.term_to_binary(3)},
-      {:set, SystemKeys.layout_log("log-abc"), :erlang.term_to_binary([0, 1])},
-      {:set, SystemKeys.layout_services(), :erlang.term_to_binary(%{"log-abc" => %{kind: :log}})},
-      {:set, SystemKeys.cluster_epoch(), :erlang.term_to_binary(1)},
-      {:set, SystemKeys.cluster_parameters_desired_logs(), :erlang.term_to_binary(2)},
-      {:set, SystemKeys.recovery_attempt(), :erlang.term_to_binary(1)}
+      {:set, SystemKeys.shard_key("g"), Values.encode_shard_key_entry(3, "")},
+      {:set, SystemKeys.layout_log("log-abc"), Values.encode_tag_list([0, 1])},
+      {:set, SystemKeys.layout_services(), Values.encode_structured(%{"log-abc" => %{kind: :log}})},
+      {:set, SystemKeys.cluster_epoch(), Values.encode_integer(1)},
+      {:set, SystemKeys.cluster_parameters_desired_logs(), Values.encode_integer(2)},
+      {:set, SystemKeys.recovery_attempt(), Values.encode_integer(1)}
     ]
 
     version = commit!(proxy, epoch, mutations, "families_key")
@@ -231,7 +232,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     )
 
     mutations = [
-      {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(5)},
+      {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(5, "")},
       {:set, <<0xFF, "/system/future/feature">>, "opaque"}
     ]
 

--- a/test/bedrock/data_plane/commit_proxy/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_test.exs
@@ -4,10 +4,11 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
   alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.Version
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   defp v(n), do: Version.from_integer(n)
 
-  defp t2b(term), do: :erlang.term_to_binary(term)
+  defp shard_val(tag, start_key \\ ""), do: Values.encode_shard_key_entry(tag, start_key)
 
   defp apply!(metadata, updates) do
     {metadata, _stats} = Metadata.apply_updates(metadata, updates)
@@ -17,30 +18,30 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
   describe "apply_updates/2 with sets" do
     test "parses every key family PersistencePhase writes into its structured slot" do
       mutations = [
-        {:set, SystemKeys.shard_key("m"), t2b(7)},
+        {:set, SystemKeys.shard_key("m"), shard_val(7)},
         {:set, SystemKeys.shard(3), "raw-shard-metadata"},
         {:set, SystemKeys.materializer_key("m"), "raw-materializers"},
-        {:set, SystemKeys.layout_log("log-1"), t2b([0, 1])},
-        {:set, SystemKeys.layout_services(), t2b(%{"log-1" => %{kind: :log}})},
-        {:set, SystemKeys.layout_id(), t2b("layout-abc")},
-        {:set, SystemKeys.cluster_coordinators(), t2b([:a@host])},
-        {:set, SystemKeys.cluster_epoch(), t2b(4)},
-        {:set, SystemKeys.cluster_policies_volunteer_nodes(), t2b(true)},
-        {:set, SystemKeys.cluster_parameters_desired_logs(), t2b(2)},
-        {:set, SystemKeys.cluster_parameters_desired_replication(), t2b(3)},
-        {:set, SystemKeys.cluster_parameters_desired_commit_proxies(), t2b(1)},
-        {:set, SystemKeys.cluster_parameters_desired_coordinators(), t2b(1)},
-        {:set, SystemKeys.cluster_parameters_desired_read_version_proxies(), t2b(1)},
-        {:set, SystemKeys.cluster_parameters_empty_transaction_timeout_ms(), t2b(1_000)},
-        {:set, SystemKeys.cluster_parameters_ping_rate_in_hz(), t2b(10)},
-        {:set, SystemKeys.cluster_parameters_retransmission_rate_in_hz(), t2b(5)},
-        {:set, SystemKeys.cluster_parameters_transaction_window_in_ms(), t2b(5_000)},
-        {:set, SystemKeys.recovery_attempt(), t2b(1)},
-        {:set, SystemKeys.recovery_state(), t2b(:completed)},
-        {:set, SystemKeys.recovery_last_completed(), t2b(123)},
-        {:set, SystemKeys.config_monolithic(), t2b({4, %{}})},
-        {:set, SystemKeys.epoch_legacy(), t2b(4)},
-        {:set, SystemKeys.last_recovery_legacy(), t2b(123)}
+        {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0, 1])},
+        {:set, SystemKeys.layout_services(), Values.encode_structured(%{"log-1" => %{kind: :log}})},
+        {:set, SystemKeys.layout_id(), Values.encode_id("layout-abc")},
+        {:set, SystemKeys.cluster_coordinators(), Values.encode_node_list([:a@host])},
+        {:set, SystemKeys.cluster_epoch(), Values.encode_integer(4)},
+        {:set, SystemKeys.cluster_policies_volunteer_nodes(), Values.encode_boolean(true)},
+        {:set, SystemKeys.cluster_parameters_desired_logs(), Values.encode_integer(2)},
+        {:set, SystemKeys.cluster_parameters_desired_replication(), Values.encode_integer(3)},
+        {:set, SystemKeys.cluster_parameters_desired_commit_proxies(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_desired_coordinators(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_desired_read_version_proxies(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_empty_transaction_timeout_ms(), Values.encode_integer(1_000)},
+        {:set, SystemKeys.cluster_parameters_ping_rate_in_hz(), Values.encode_integer(10)},
+        {:set, SystemKeys.cluster_parameters_retransmission_rate_in_hz(), Values.encode_integer(5)},
+        {:set, SystemKeys.cluster_parameters_transaction_window_in_ms(), Values.encode_integer(5_000)},
+        {:set, SystemKeys.recovery_attempt(), Values.encode_integer(1)},
+        {:set, SystemKeys.recovery_state(), Values.encode_atom(:completed)},
+        {:set, SystemKeys.recovery_last_completed(), Values.encode_integer(123)},
+        {:set, SystemKeys.config_monolithic(), Values.encode_structured({4, %{}})},
+        {:set, SystemKeys.epoch_legacy(), Values.encode_integer(4)},
+        {:set, SystemKeys.last_recovery_legacy(), Values.encode_integer(123)}
       ]
 
       {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), mutations}])
@@ -93,8 +94,8 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
     test "later version wins and version advances" do
       metadata =
         Metadata.new()
-        |> apply!([{v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}]}])
-        |> apply!([{v(2), [{:set, SystemKeys.shard_key("m"), t2b(9)}]}])
+        |> apply!([{v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}]}])
+        |> apply!([{v(2), [{:set, SystemKeys.shard_key("m"), shard_val(9)}]}])
 
       assert metadata.shards == %{"m" => 9}
       assert metadata.version == v(2)
@@ -102,8 +103,8 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
 
     test "entries at or below the applied version are skipped (idempotent redelivery)" do
       window = [
-        {v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}]},
-        {v(2), [{:set, SystemKeys.shard_key("m"), t2b(9)}]}
+        {v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}]},
+        {v(2), [{:set, SystemKeys.shard_key("m"), shard_val(9)}]}
       ]
 
       metadata = apply!(Metadata.new(), window)
@@ -118,7 +119,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
     test "within a version, later mutation wins" do
       metadata =
         apply!(Metadata.new(), [
-          {v(1), [{:set, SystemKeys.shard_key("m"), t2b(7)}, {:set, SystemKeys.shard_key("m"), t2b(8)}]}
+          {v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}, {:set, SystemKeys.shard_key("m"), shard_val(8)}]}
         ])
 
       assert metadata.shards == %{"m" => 8}
@@ -131,9 +132,9 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
         apply!(Metadata.new(), [
           {v(1),
            [
-             {:set, SystemKeys.shard_key("m"), t2b(7)},
-             {:set, SystemKeys.layout_log("log-1"), t2b([0])},
-             {:set, SystemKeys.layout_id(), t2b("layout-abc")}
+             {:set, SystemKeys.shard_key("m"), shard_val(7)},
+             {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+             {:set, SystemKeys.layout_id(), Values.encode_id("layout-abc")}
            ]},
           {v(2), [{:clear, SystemKeys.shard_key("m")}, {:clear, SystemKeys.layout_id()}]}
         ])
@@ -148,10 +149,10 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
         apply!(Metadata.new(), [
           {v(1),
            [
-             {:set, SystemKeys.shard_key("a"), t2b(1)},
-             {:set, SystemKeys.shard_key("m"), t2b(2)},
-             {:set, SystemKeys.shard_key("z"), t2b(3)},
-             {:set, SystemKeys.layout_log("log-1"), t2b([0])}
+             {:set, SystemKeys.shard_key("a"), shard_val(1)},
+             {:set, SystemKeys.shard_key("m"), shard_val(2)},
+             {:set, SystemKeys.shard_key("z"), shard_val(3)},
+             {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}
            ]}
         ])
 
@@ -177,7 +178,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
         Metadata.apply_updates(Metadata.new(), [
           {v(1),
            [
-             {:set, SystemKeys.shard_key("m"), t2b(7)},
+             {:set, SystemKeys.shard_key("m"), shard_val(7)},
              {:set, unknown_key, "opaque"},
              {:clear, non_system_metadata_key}
            ]}
@@ -198,10 +199,24 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
       assert stats.skipped_keys == [key]
     end
 
+    test "values that fail to decode are skipped and counted, never raise" do
+      key = SystemKeys.shard_key("m")
+
+      {metadata, stats} =
+        Metadata.apply_updates(Metadata.new(), [
+          {v(1), [{:set, key, "garbage-not-an-encoded-value"}, {:set, SystemKeys.cluster_epoch(), <<0xFF, 0xFF>>}]}
+        ])
+
+      assert metadata.shards == %{}
+      assert metadata.cluster == %{}
+      assert stats.applied == 0
+      assert stats.skipped_keys == [key, SystemKeys.cluster_epoch()]
+    end
+
     test "unknown cluster parameters are ignored and counted" do
       key = SystemKeys.system_prefix() <> "/cluster/parameters/future_knob"
 
-      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:set, key, t2b(1)}]}])
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:set, key, Values.encode_integer(1)}]}])
 
       assert metadata.parameters == %{}
       assert stats.skipped_keys == [key]

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   describe "new_empty/0" do
     test "creates empty routing data with all fields initialized" do
@@ -294,7 +295,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     test "handles shard_key set mutation" do
       routing_data = RoutingData.new_empty()
       key = SystemKeys.shard_key("m")
-      value = :erlang.term_to_binary(42)
+      value = Values.encode_shard_key_entry(42, "")
       updates = [{100, [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -310,9 +311,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(1)},
-           {:set, SystemKeys.shard_key("m"), :erlang.term_to_binary(2)},
-           {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(3)}
+           {:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")},
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(2, "")},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(3, "")}
          ]}
       ]
 
@@ -330,7 +331,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       key = SystemKeys.layout_log("log-123")
       # layout_log stores log descriptor (tags) as erlang term
       log_descriptor = [0, 1]
-      value = :erlang.term_to_binary(log_descriptor)
+      value = Values.encode_tag_list(log_descriptor)
       updates = [{100, [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -349,8 +350,8 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.layout_log("log-1"), :erlang.term_to_binary([0])},
-           {:set, SystemKeys.layout_log("log-2"), :erlang.term_to_binary([1])}
+           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
          ]}
       ]
 
@@ -400,9 +401,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100, [{:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(1)}]},
-        {101, [{:set, SystemKeys.shard_key("b"), :erlang.term_to_binary(2)}]},
-        {102, [{:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(99)}]}
+        {100, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
+        {101, [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "")}]},
+        {102, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
       ]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -462,10 +463,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.shard_key("m"), :erlang.term_to_binary(1)},
-           {:set, SystemKeys.layout_log("log-1"), :erlang.term_to_binary([0])},
-           {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(2)},
-           {:set, SystemKeys.layout_log("log-2"), :erlang.term_to_binary([1])}
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")},
+           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(2, "")},
+           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
          ]}
       ]
 

--- a/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
@@ -31,6 +31,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
   alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys.Values
 
   defp encode_tx(key) do
     Transaction.encode(%{
@@ -71,8 +72,8 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     v1 = Version.from_integer(1)
     v2 = Version.from_integer(2)
 
-    mutation1 = {:set, <<0xFF, "/system/shard_keys/a">>, :erlang.term_to_binary(1)}
-    mutation2 = {:set, <<0xFF, "/system/shard_keys/b">>, :erlang.term_to_binary(2)}
+    mutation1 = {:set, <<0xFF, "/system/shard_keys/a">>, Values.encode_shard_key_entry(1, "")}
+    mutation2 = {:set, <<0xFF, "/system/shard_keys/b">>, Values.encode_shard_key_entry(2, "")}
 
     assert {:ok, [], window1} = resolve_from_fresh_task(resolver, v0, v1, "k1", [mutation1])
     assert {:ok, [], window2} = resolve_from_fresh_task(resolver, v1, v2, "k2", [mutation2])

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -1,0 +1,226 @@
+defmodule Bedrock.SystemKeys.ValuesTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  describe "integer round-trip" do
+    property "encodes and decodes any integer" do
+      check all(i <- integer()) do
+        assert {:ok, ^i} = i |> Values.encode_integer() |> Values.decode_integer()
+      end
+    end
+
+    test "large timestamps round-trip" do
+      ts = System.system_time(:millisecond)
+      assert {:ok, ^ts} = ts |> Values.encode_integer() |> Values.decode_integer()
+    end
+
+    test "decoding a non-integer value returns an error" do
+      assert {:error, _} = Values.decode_integer(Values.encode_id("not-an-int"))
+    end
+  end
+
+  describe "boolean round-trip" do
+    test "true and false round-trip" do
+      assert {:ok, true} = true |> Values.encode_boolean() |> Values.decode_boolean()
+      assert {:ok, false} = false |> Values.encode_boolean() |> Values.decode_boolean()
+    end
+
+    test "decoding a non-boolean value returns an error" do
+      assert {:error, _} = Values.decode_boolean(Values.encode_integer(7))
+    end
+  end
+
+  describe "atom round-trip" do
+    property "atoms round-trip as strings" do
+      check all(a <- member_of([:completed, :running, :stalled, :a@host])) do
+        assert {:ok, ^a} = a |> Values.encode_atom() |> Values.decode_atom()
+      end
+    end
+  end
+
+  describe "id round-trip" do
+    property "binary ids round-trip" do
+      check all(id <- binary()) do
+        assert {:ok, ^id} = id |> Values.encode_id() |> Values.decode_id()
+      end
+    end
+
+    property "integer ids round-trip" do
+      check all(id <- non_negative_integer()) do
+        assert {:ok, ^id} = id |> Values.encode_id() |> Values.decode_id()
+      end
+    end
+  end
+
+  describe "node list round-trip" do
+    property "lists of node atoms round-trip" do
+      check all(nodes <- list_of(member_of([:a@host, :b@host, :c@other]))) do
+        assert {:ok, ^nodes} = nodes |> Values.encode_node_list() |> Values.decode_node_list()
+      end
+    end
+
+    test "decoding a non-list returns an error" do
+      assert {:error, _} = Values.decode_node_list(Values.encode_integer(1))
+    end
+  end
+
+  describe "tag list round-trip (log descriptors)" do
+    property "lists of integer tags round-trip" do
+      check all(tags <- list_of(non_negative_integer())) do
+        assert {:ok, ^tags} = tags |> Values.encode_tag_list() |> Values.decode_tag_list()
+      end
+    end
+
+    test "decoding a list containing non-integers returns an error" do
+      assert {:error, _} = Values.decode_tag_list(Values.encode_node_list([:a@host]))
+    end
+  end
+
+  describe "shard key entry round-trip" do
+    property "{tag, start_key} round-trips" do
+      check all(
+              tag <- non_negative_integer(),
+              start_key <- binary()
+            ) do
+        assert {:ok, {^tag, ^start_key}} =
+                 tag
+                 |> Values.encode_shard_key_entry(start_key)
+                 |> Values.decode_shard_key_entry()
+      end
+    end
+
+    test "decoding a bare integer returns an error" do
+      assert {:error, _} = Values.decode_shard_key_entry(Values.encode_integer(7))
+    end
+  end
+
+  describe "structured round-trip (versioned)" do
+    property "nested config-shaped terms round-trip" do
+      check all(term <- structured_term()) do
+        assert {:ok, ^term} = term |> Values.encode_structured() |> Values.decode_structured()
+      end
+    end
+
+    test "config_monolithic shape round-trips" do
+      config = {4, %{coordinators: [:a@host], parameters: %{desired_logs: 2}, policies: %{}}}
+      assert {:ok, ^config} = config |> Values.encode_structured() |> Values.decode_structured()
+    end
+
+    test "service map shape round-trips" do
+      services = %{
+        "log-1" => %{kind: :log, status: :unknown, last_seen: {:worker_1, :a@host}},
+        "mat-1" => %{kind: :materializer, status: :down, last_seen: nil}
+      }
+
+      assert {:ok, ^services} = services |> Values.encode_structured() |> Values.decode_structured()
+    end
+
+    test "encoding a pid raises (writers must sanitize)" do
+      assert_raise ArgumentError, fn -> Values.encode_structured(%{status: {:up, self()}}) end
+    end
+
+    test "unsupported version byte returns an error" do
+      <<_version, rest::binary>> = Values.encode_structured(%{})
+      assert {:error, _} = Values.decode_structured(<<255, rest::binary>>)
+    end
+
+    test "truncated payload returns an error" do
+      encoded = Values.encode_structured({1, %{a: [1, 2, 3]}})
+      truncated = binary_part(encoded, 0, byte_size(encoded) - 2)
+      assert {:error, _} = Values.decode_structured(truncated)
+    end
+  end
+
+  describe "decode_for/2 family dispatch" do
+    test "dispatches every family PersistencePhase writes" do
+      assert {:ok, {7, "a"}} = Values.decode_for({:shard_key, "m"}, Values.encode_shard_key_entry(7, "a"))
+      assert {:ok, "opaque"} = Values.decode_for({:shard, "3"}, "opaque")
+      assert {:ok, "opaque"} = Values.decode_for({:materializer_key, "m"}, "opaque")
+      assert {:ok, [0, 1]} = Values.decode_for({:layout_log, "log-1"}, Values.encode_tag_list([0, 1]))
+      assert {:ok, %{}} = Values.decode_for(:layout_services, Values.encode_structured(%{}))
+      assert {:ok, "layout-abc"} = Values.decode_for(:layout_id, Values.encode_id("layout-abc"))
+      assert {:ok, [:a@host]} = Values.decode_for({:cluster, :coordinators}, Values.encode_node_list([:a@host]))
+      assert {:ok, 4} = Values.decode_for({:cluster, :epoch}, Values.encode_integer(4))
+      assert {:ok, true} = Values.decode_for({:cluster_policy, :volunteer_nodes}, Values.encode_boolean(true))
+      assert {:ok, 2} = Values.decode_for({:cluster_parameter, :desired_logs}, Values.encode_integer(2))
+      assert {:ok, 1} = Values.decode_for({:recovery, :attempt}, Values.encode_integer(1))
+      assert {:ok, :completed} = Values.decode_for({:recovery, :state}, Values.encode_atom(:completed))
+      assert {:ok, 123} = Values.decode_for({:recovery, :last_completed}, Values.encode_integer(123))
+      assert {:ok, {4, %{}}} = Values.decode_for(:config_monolithic, Values.encode_structured({4, %{}}))
+      assert {:ok, 4} = Values.decode_for(:epoch_legacy, Values.encode_integer(4))
+      assert {:ok, 123} = Values.decode_for(:last_recovery_legacy, Values.encode_integer(123))
+    end
+
+    test "a parsed key family without a decoder returns an error instead of raising" do
+      assert {:error, :unknown_family} = Values.decode_for({:future_family, "x"}, "anything")
+    end
+
+    property "garbage bytes never raise, for any parsed key family" do
+      families = [
+        {:shard_key, "m"},
+        {:layout_log, "log-1"},
+        :layout_services,
+        :layout_id,
+        {:cluster, :coordinators},
+        {:cluster, :epoch},
+        {:cluster_policy, :volunteer_nodes},
+        {:cluster_parameter, :desired_logs},
+        {:recovery, :attempt},
+        {:recovery, :state},
+        {:recovery, :last_completed},
+        :config_monolithic,
+        :epoch_legacy,
+        :last_recovery_legacy
+      ]
+
+      check all(
+              garbage <- binary(min_length: 1),
+              parsed <- member_of(families)
+            ) do
+        # Must return a tagged result -- never raise or exit
+        result = Values.decode_for(parsed, garbage)
+        assert match?({:ok, _}, result) or match?({:error, _}, result)
+      end
+    end
+  end
+
+  describe "no term_to_binary in encoded output" do
+    test "encoded values are not decodable as external term format" do
+      # BERT payloads start with 131; none of our encodings should
+      refute match?(<<131, _::binary>>, Values.encode_integer(7))
+      refute match?(<<131, _::binary>>, Values.encode_structured(%{a: 1}))
+      refute match?(<<131, _::binary>>, Values.encode_shard_key_entry(1, ""))
+    end
+  end
+
+  # A generator approximating the shapes stored in config_monolithic /
+  # layout_services: maps and tuples of atoms, binaries, integers, lists.
+  defp structured_term do
+    leaf =
+      one_of([
+        constant(nil),
+        boolean(),
+        integer(),
+        binary(),
+        member_of([:log, :materializer, :down, :unknown, :a@host])
+      ])
+
+    tree(leaf, fn child ->
+      one_of([
+        list_of(child, max_length: 3),
+        map_of(one_of([binary(), member_of([:kind, :status, :last_seen])]), child, max_length: 3),
+        bind(list_of(child, max_length: 3), fn elems -> constant(List.to_tuple(elems)) end)
+      ])
+    end)
+  end
+
+  # Sanity: SystemKeys.parse_key output feeds decode_for
+  test "parse_key output is accepted by decode_for" do
+    key = SystemKeys.shard_key("m")
+    parsed = SystemKeys.parse_key(key)
+    assert {:ok, {7, ""}} = Values.decode_for(parsed, Values.encode_shard_key_entry(7, ""))
+  end
+end

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -39,6 +39,13 @@ defmodule Bedrock.SystemKeys.ValuesTest do
         assert {:ok, ^a} = a |> Values.encode_atom() |> Values.decode_atom()
       end
     end
+
+    test "decoding a string that names no existing atom errors and creates no atom" do
+      string = "bedrock_values_test_never_an_atom_#{System.unique_integer([:positive])}"
+
+      assert {:error, :unknown_atom} = Values.decode_atom(Values.encode_id(string))
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
+    end
   end
 
   describe "id round-trip" do
@@ -64,6 +71,14 @@ defmodule Bedrock.SystemKeys.ValuesTest do
 
     test "decoding a non-list returns an error" do
       assert {:error, _} = Values.decode_node_list(Values.encode_integer(1))
+    end
+
+    test "a node name that is not an existing atom errors and creates no atom" do
+      string = "unknown_node_#{System.unique_integer([:positive])}@nowhere"
+      encoded = Bedrock.Encoding.Tuple.pack([string])
+
+      assert {:error, :unknown_atom} = Values.decode_node_list(encoded)
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
     end
   end
 
@@ -131,6 +146,15 @@ defmodule Bedrock.SystemKeys.ValuesTest do
       encoded = Values.encode_structured({1, %{a: [1, 2, 3]}})
       truncated = binary_part(encoded, 0, byte_size(encoded) - 2)
       assert {:error, _} = Values.decode_structured(truncated)
+    end
+
+    test "an atom payload naming no existing atom errors and creates no atom" do
+      string = "bedrock_structured_never_an_atom_#{System.unique_integer([:positive])}"
+      # v1 wire format: version byte 0x01, atom tag 0x03, 16-bit length, bytes
+      payload = <<0x01, 0x03, byte_size(string)::16, string::binary>>
+
+      assert {:error, :invalid_encoding} = Values.decode_structured(payload)
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
     end
   end
 


### PR DESCRIPTION
## Summary

Ticket **bedrock-ri40** (Phase B prerequisite): every `\xFF/system` value family now has a deliberate, explicit encoding via the new `Bedrock.SystemKeys.Values` module. `:erlang.binary_to_term/1` is eliminated from all system-key read paths.

### Per-family encodings

| Family | Encoding | Rationale |
|---|---|---|
| epochs, parameters, timestamps, recovery attempt | FDB tuple int (`Bedrock.Encoding.Tuple`) | simple scalar; key identifies the family; tuple tags are self-describing and language-neutral |
| policies (booleans) | FDB tuple int 0/1 | no boolean in tuple encoding; explicit mapping |
| recovery state (atom) | FDB tuple string | atoms-as-strings |
| layout id | FDB tuple int-or-binary | id type is in flux (spec says int, tests use strings) |
| coordinators | FDB tuple list of node-name strings | atoms-as-strings |
| log descriptors | FDB tuple list of int tags | matches `LogDescriptor.t` |
| `shard_key` | FDB tuple `{tag, start_key}` | **also fixes a latent bug**: the materializer bootstrap (the only cross-epoch reader) expected `{tag, start_key}` while the writer stored a bare tag — the default path would have crashed with a `MatchError` on real data |
| `config_monolithic`, `layout_services` | versioned explicit term codec (version byte `0x01`; nil/bool/atom/binary/int64/float/tuple/list/map; canonical sorted-map encoding) | nested heterogeneous maps; version byte allows format evolution; PIDs/refs/funs rejected at encode time |
| `shard/1`, `materializer_key/1` | unchanged FlatBuffers (`ShardMetadata`, `MaterializerList`) | already properly encoded; opaque to the metadata pipeline |

The structured codec is deliberately NOT added to `Bedrock.Encoding.Tuple`: that module implements the FDB tuple wire format used for keyspace keys, and non-standard atom/map tags would break that compatibility.

### Decode safety

Decoders never raise. Commit-proxy `Metadata` and `RoutingData` skip (and count in stats/telemetry) undecodable values; `decode_for/2` has a defensive catch-all so a future key family added to `parse_key/1` without a decoder degrades to a skip, not a commit-proxy crash. The materializer bootstrap returns `{:error, {:invalid_shard_value, key, reason}}` (recovery stalls with a reason) instead of raising.

Writers raise on invalid input (trusted, and a bad value in the durable layout should fail loudly at persist time). Live `{:up, pid}` service statuses are sanitized to `:unknown` before writing `layout_services` — runtime refs are re-populated by the director, never read back from storage.

### Migration / prior-epoch reads (verified)

**No migration needed.** All system keys are rewritten by `PersistencePhase` on every recovery. The only reader of system keys written by a *prior* epoch is `MaterializerBootstrapPhase.default_get_shard_layout/2`, and it could not decode the old bare-tag format anyway (pre-existing mismatch, masked in tests by the injected `get_shard_layout_fn`). Coordinator cold boot uses the `ClusterBootstrap` FlatBuffer in object storage, not system keys. Pre-1.0, no released cluster carries persistent system keys across upgrades.

### Testing

- New `test/bedrock/system_keys/values_test.exs`: round-trip property tests per family (StreamData), garbage-decode-never-raises property across all families, version-byte and truncation error tests, pid-rejection test.
- `Metadata` gains a decode-of-garbage skip test; producer sides of existing metadata/routing/integration tests switched to the new encoders with **all parsed-content assertions unchanged** (the #105 integration test still asserts `shards: %{"m" => 7}` etc.).
- Full suite: 13 doctests, 167 properties, 2671 tests, 0 failures. Targeted system_keys + commit_proxy + resolver + control_plane suites green at 2 seeds. `mix format`, `credo --strict` (0 issues), `dialyzer` (0 errors).

### Gating audit

8-angle review run; confirmed findings fixed: nil policy value crash (`|| false` normalization matching `build_policies/1`), missing `decode_for` catch-all, map decode allocation waste. Refuted: pid-in-`config_monolithic` (Config.t carries no `transaction_system_layout`), vacancy tuples reaching `encode_tag_list` (resolved during log recruitment, and raising on a leaked vacancy is correct).