### PR TITLE
Record read conflicts when a read is issued; cover key-selector scan spans (bedrock-udr, bedrock-v2c)

### DIFF
--- a/lib/bedrock/internal/transaction_builder/point_reads.ex
+++ b/lib/bedrock/internal/transaction_builder/point_reads.ex
@@ -61,6 +61,8 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
 
     case ensure_read_version(t, opts) do
       {:ok, t} ->
+        t = record_read_intent(t, key, opts)
+
         execute_get_query(
           t,
           key,
@@ -70,6 +72,18 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
 
       {:failure, failures_by_reason} ->
         {t, {:failure, failures_by_reason}}
+    end
+  end
+
+  # The conflict is registered when the read is issued, not when the result
+  # returns: a read that comes back empty still constrains the transaction's
+  # outcome, so the resolver must see it regardless of the result's shape.
+  @spec record_read_intent(State.t(), Bedrock.key(), keyword()) :: State.t()
+  defp record_read_intent(t, key, opts) do
+    if Keyword.get(opts, :snapshot, false) do
+      t
+    else
+      %{t | tx: Tx.add_read_conflict_key(t.tx, key)}
     end
   end
 

--- a/lib/bedrock/internal/transaction_builder/point_reads.ex
+++ b/lib/bedrock/internal/transaction_builder/point_reads.ex
@@ -13,6 +13,7 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
   alias Bedrock.Internal.TransactionBuilder.State
   alias Bedrock.Internal.TransactionBuilder.StorageRacing
   alias Bedrock.Internal.TransactionBuilder.Tx
+  alias Bedrock.Key
   alias Bedrock.KeySelector
 
   @type storage_get_key_fn() :: (pid(), binary(), Bedrock.version(), keyword() ->
@@ -116,9 +117,9 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
 
     case ensure_read_version(t, opts) do
       {:ok, t} ->
-        execute_get_query(
+        execute_selector_query(
           t,
-          key_selector.key,
+          key_selector,
           &case storage_get_key_selector_fn.(&1, key_selector, &2, timeout: &3) do
             {:ok, nil} -> {:ok, nil}
             {:ok, {resolved_key, value}} -> {:ok, {resolved_key, value}}
@@ -134,6 +135,53 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
   end
 
   # Private helper functions
+
+  # A selector's conflict range can only be computed after resolution: any
+  # mutation between the anchor key and the resolved key would change what the
+  # selector resolves to, so the whole scanned span must reach the resolver.
+  # When nothing resolves, the scanned shard range was read as empty and is
+  # recorded whole.
+  defp execute_selector_query(state, key_selector, operation_fn, opts) do
+    snapshot = Keyword.get(opts, :snapshot, false)
+
+    state
+    |> StorageRacing.race_storage_servers(key_selector.key, operation_fn)
+    |> case do
+      {state, {:failure, failures_by_reason}} ->
+        {state, {:failure, failures_by_reason}}
+
+      {state, {:ok, {nil, {shard_start, shard_end}}}} ->
+        state =
+          if snapshot do
+            state
+          else
+            %{state | tx: Tx.add_read_conflict_range(state.tx, shard_start, shard_end)}
+          end
+
+        {state, {:error, :not_found}}
+
+      {state, {:ok, {{resolved_key, value}, _shard_range}}} ->
+        state =
+          if snapshot do
+            state
+          else
+            {span_start, span_end} = selector_scan_span(key_selector.key, resolved_key)
+
+            tx =
+              state.tx
+              |> Tx.merge_storage_read(resolved_key, value)
+              |> Tx.add_read_conflict_range(span_start, span_end)
+
+            %{state | tx: tx}
+          end
+
+        {state, {:ok, {resolved_key, value}}}
+    end
+  end
+
+  defp selector_scan_span(anchor, resolved_key) when anchor <= resolved_key, do: {anchor, Key.key_after(resolved_key)}
+
+  defp selector_scan_span(anchor, resolved_key), do: {resolved_key, Key.key_after(anchor)}
 
   defp execute_get_query(state, racing_key, operation_fn, opts) do
     snapshot = Keyword.get(opts, :snapshot, false)

--- a/lib/bedrock/internal/transaction_builder/point_reads.ex
+++ b/lib/bedrock/internal/transaction_builder/point_reads.ex
@@ -160,6 +160,23 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
 
         {state, {:error, :not_found}}
 
+      {state, {:ok, {{resolved_key, nil}, _shard_range}}} ->
+        state =
+          if snapshot do
+            state
+          else
+            {span_start, span_end} = selector_scan_span(key_selector.key, resolved_key)
+
+            tx =
+              state.tx
+              |> Tx.merge_storage_read(resolved_key, :not_found)
+              |> Tx.add_read_conflict_range(span_start, span_end)
+
+            %{state | tx: tx}
+          end
+
+        {state, {:error, :not_found}}
+
       {state, {:ok, {{resolved_key, value}, _shard_range}}} ->
         state =
           if snapshot do

--- a/test/bedrock/internal/transaction_builder/point_reads_test.exs
+++ b/test/bedrock/internal/transaction_builder/point_reads_test.exs
@@ -1,10 +1,12 @@
 defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.Internal.TransactionBuilder.LayoutIndex
   alias Bedrock.Internal.TransactionBuilder.PointReads
   alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Internal.TransactionBuilder.Tx
   alias Bedrock.Key
 
   defp build_state do
@@ -60,5 +62,40 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
 
     assert tx.range_reads == []
     assert tx.reads == %{}
+  end
+
+  test "snapshot point read that hits storage records no read conflict" do
+    key = "present-key"
+    state = build_state()
+
+    storage_get_key_fn = fn _pid, ^key, _version, _opts ->
+      {:ok, "value"}
+    end
+
+    assert {%State{tx: tx}, {:ok, {^key, "value"}}} =
+             PointReads.get_key(state, key,
+               storage_get_key_fn: storage_get_key_fn,
+               snapshot: true
+             )
+
+    assert tx.range_reads == []
+    assert tx.reads == %{}
+  end
+
+  test "missed point read reaches the resolver as a committed read conflict" do
+    key = "missing-key"
+    state = build_state()
+
+    storage_get_key_fn = fn _pid, ^key, _version, _opts ->
+      {:error, :not_found}
+    end
+
+    {%State{tx: tx, read_version: read_version}, {:error, :not_found}} =
+      PointReads.get_key(state, key, storage_get_key_fn: storage_get_key_fn)
+
+    encoded = Tx.commit(tx, read_version)
+
+    assert {:ok, {^read_version, read_conflicts}} = Transaction.read_conflicts(encoded)
+    assert {key, Key.key_after(key)} in read_conflicts
   end
 end

--- a/test/bedrock/internal/transaction_builder/point_reads_test.exs
+++ b/test/bedrock/internal/transaction_builder/point_reads_test.exs
@@ -113,6 +113,35 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
       assert {"kangaroo", Key.key_after("m")} in tx.range_reads
     end
 
+    test "selector resolving exactly to its anchor records the single-key span" do
+      selector = KeySelector.first_greater_or_equal("m")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts ->
+        {:ok, {"m", "exact"}}
+      end
+
+      assert {%State{tx: tx}, {:ok, {"m", "exact"}}} =
+               PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      assert {"m", Key.key_after("m")} in tx.range_reads
+    end
+
+    test "selector resolving to a key with nil value records the span and misses" do
+      selector = KeySelector.first_greater_or_equal("m")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts ->
+        {:ok, {"moose", nil}}
+      end
+
+      assert {%State{tx: tx}, {:error, :not_found}} =
+               PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      assert {"m", Key.key_after("moose")} in tx.range_reads
+      assert %{"moose" => :clear} = tx.reads
+    end
+
     test "selector that resolves to nothing records the scanned shard range" do
       selector = KeySelector.first_greater_or_equal("zzz")
       state = build_state()

--- a/test/bedrock/internal/transaction_builder/point_reads_test.exs
+++ b/test/bedrock/internal/transaction_builder/point_reads_test.exs
@@ -1,0 +1,64 @@
+defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.PointReads
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Key
+
+  defp build_state do
+    %State{
+      layout_index: %LayoutIndex{
+        tree: :gb_trees.from_orddict([{<<0xFF, 0xFF>>, {"", [self()]}}])
+      },
+      read_version: Version.from_integer(42)
+    }
+  end
+
+  test "point read that misses storage still records a read conflict" do
+    key = "missing-key"
+    state = build_state()
+
+    storage_get_key_fn = fn _pid, ^key, _version, _opts ->
+      {:error, :not_found}
+    end
+
+    assert {%State{tx: tx}, {:error, :not_found}} =
+             PointReads.get_key(state, key, storage_get_key_fn: storage_get_key_fn)
+
+    assert {key, Key.key_after(key)} in tx.range_reads
+  end
+
+  test "point read that hits storage records a read conflict" do
+    key = "present-key"
+    state = build_state()
+
+    storage_get_key_fn = fn _pid, ^key, _version, _opts ->
+      {:ok, "value"}
+    end
+
+    assert {%State{tx: tx}, {:ok, {^key, "value"}}} =
+             PointReads.get_key(state, key, storage_get_key_fn: storage_get_key_fn)
+
+    assert {key, Key.key_after(key)} in tx.range_reads
+  end
+
+  test "snapshot point read that misses storage records no read conflict" do
+    key = "missing-key"
+    state = build_state()
+
+    storage_get_key_fn = fn _pid, ^key, _version, _opts ->
+      {:error, :not_found}
+    end
+
+    assert {%State{tx: tx}, {:error, :not_found}} =
+             PointReads.get_key(state, key,
+               storage_get_key_fn: storage_get_key_fn,
+               snapshot: true
+             )
+
+    assert tx.range_reads == []
+    assert tx.reads == %{}
+  end
+end

--- a/test/bedrock/internal/transaction_builder/point_reads_test.exs
+++ b/test/bedrock/internal/transaction_builder/point_reads_test.exs
@@ -8,6 +8,7 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
   alias Bedrock.Internal.TransactionBuilder.State
   alias Bedrock.Internal.TransactionBuilder.Tx
   alias Bedrock.Key
+  alias Bedrock.KeySelector
 
   defp build_state do
     %State{
@@ -80,6 +81,90 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReadsTest do
 
     assert tx.range_reads == []
     assert tx.reads == %{}
+  end
+
+  describe "key-selector read conflicts" do
+    test "forward selector hit records the span from anchor to resolved key" do
+      selector = KeySelector.first_greater_or_equal("m")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts ->
+        {:ok, {"moose", "antlers"}}
+      end
+
+      assert {%State{tx: tx}, {:ok, {"moose", "antlers"}}} =
+               PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      assert {"m", Key.key_after("moose")} in tx.range_reads
+      assert %{"moose" => "antlers"} = tx.reads
+    end
+
+    test "backward selector hit records the span from resolved key to anchor" do
+      selector = KeySelector.last_less_or_equal("m")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts ->
+        {:ok, {"kangaroo", "pouch"}}
+      end
+
+      assert {%State{tx: tx}, {:ok, {"kangaroo", "pouch"}}} =
+               PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      assert {"kangaroo", Key.key_after("m")} in tx.range_reads
+    end
+
+    test "selector that resolves to nothing records the scanned shard range" do
+      selector = KeySelector.first_greater_or_equal("zzz")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts ->
+        {:ok, nil}
+      end
+
+      assert {%State{tx: tx}, {:error, :not_found}} =
+               PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      assert {"", <<0xFF, 0xFF>>} in tx.range_reads
+    end
+
+    test "snapshot selector reads record no conflicts on hit or miss" do
+      selector = KeySelector.first_greater_or_equal("m")
+      state = build_state()
+
+      hit_fn = fn _pid, ^selector, _version, _opts -> {:ok, {"moose", "antlers"}} end
+      miss_fn = fn _pid, ^selector, _version, _opts -> {:ok, nil} end
+
+      assert {%State{tx: hit_tx}, {:ok, _}} =
+               PointReads.get_key_selector(state, selector,
+                 storage_get_key_selector_fn: hit_fn,
+                 snapshot: true
+               )
+
+      assert {%State{tx: miss_tx}, {:error, :not_found}} =
+               PointReads.get_key_selector(state, selector,
+                 storage_get_key_selector_fn: miss_fn,
+                 snapshot: true
+               )
+
+      assert hit_tx.range_reads == []
+      assert miss_tx.range_reads == []
+      assert miss_tx.reads == %{}
+    end
+
+    test "selector miss reaches the resolver as a committed read conflict" do
+      selector = KeySelector.first_greater_or_equal("zzz")
+      state = build_state()
+
+      storage_fn = fn _pid, ^selector, _version, _opts -> {:ok, nil} end
+
+      {%State{tx: tx, read_version: read_version}, {:error, :not_found}} =
+        PointReads.get_key_selector(state, selector, storage_get_key_selector_fn: storage_fn)
+
+      encoded = Tx.commit(tx, read_version)
+
+      assert {:ok, {^read_version, read_conflicts}} = Transaction.read_conflicts(encoded)
+      assert {"", <<0xFF, 0xFF>>} in read_conflicts
+    end
   end
 
   test "missed point read reaches the resolver as a committed read conflict" do


### PR DESCRIPTION
## Why

Two transactions could both read a missing key, both write it, and both commit:

```
Transaction A                     Transaction B
get("job/123/owner") → not found
                                  get("job/123/owner") → not found
set("job/123/owner", "worker-A")
                                  set("job/123/owner", "worker-B")
commit ✓                          commit ✓   ← should have aborted
```

The resolver can only abort B if A's read conflict set contains the key — but a storage miss (`{:error, :not_found}`) took an error path that skipped conflict recording entirely. **Reading nothing is still reading:** "the key was absent" is information the transaction acted on. (Same defect as #108; found via Job Queue QA.)

Key-selector reads had the same hole, wider: a selector's result depends on *every* key between its anchor and the key it resolves to — an insert anywhere in that span changes the resolution — but only the resolved key was recorded on a hit, and nothing on a miss.

## What

Both fixes follow FoundationDB (`fdbclient/NativeAPI.actor.cpp`):

- **Point reads** register the conflict **when the read is issued**, before storage answers (`record_read_intent/3`). No result shape — value, miss, or error — can dodge it, because recording never looks at the result. Mirrors `Transaction::get()`'s `push_back(singleKeyRange(key))` before the read.
- **Selector reads** register **after resolution** (the span isn't knowable earlier — FDB's `extraConflictRanges`): a hit records `[min(anchor, resolved), key_after(max(anchor, resolved)))`; a miss records the shard range that was scanned and found empty (FDB's empty-range-read analog).

Deliberate, FDB-matching behaviors: `snapshot: true` reads record nothing; reads satisfied from your own writes record nothing; a point read that *fails* after issue still leaves its conflict behind.

## Validation

TDD, red/green verified: 7 of 12 tests fail with the `lib/` change reverted (miss/hit/span/commit-visibility); snapshot tests pass on both sides as negative controls. Two tests assert end-to-end that the conflict survives `Tx.commit/2` into `Transaction.read_conflicts/1` — what the resolver actually sees.

The selector change passed a fresh-agent adversarial audit (span math verified as a superset for all four selector constructors and arbitrary offsets; pattern-match completeness and caller contracts checked; no confirmed defects). Audit hardening included: keyed-nil selector results record the span and cache the miss. A pre-existing storage-side selector arithmetic inconsistency the audit surfaced is filed as bedrock-mi1.

Full suite: 2,524 tests, 0 failures. Credo and dialyzer clean.

Related: #108 (alternative fix for the point-read case) · tickets bedrock-udr, bedrock-v2c
