### PR TITLE
Fix three flaky test races failing develop CI (bedrock-yp2)

### DIFF
--- a/test/bedrock/control_plane/distributor/readoption_test.exs
+++ b/test/bedrock/control_plane/distributor/readoption_test.exs
@@ -325,13 +325,13 @@ defmodule Bedrock.ControlPlane.Distributor.ReadoptionTest do
 
     ref = Process.monitor(distributor)
 
-    %State{placeholder: placeholder} = :sys.get_state(distributor)
-    assert_receive {:apply_tsl_delta, %{1 => ^placeholder}, @epoch}, 5_000
+    assert_receive {:apply_tsl_delta, %{1 => _placeholder}, @epoch}, 5_000
     assert_receive {:apply_tsl_delta, %{1 => _adopted}, @epoch}, 5_000
 
     # The re-adoption delta was rejected as superseded: this distributor
-    # cedes to the newer epoch's distributor.
-    assert_receive {:DOWN, ^ref, :process, ^distributor, :normal}, 5_000
+    # cedes to the newer epoch's distributor. :noproc if it exited before
+    # the monitor attached.
+    assert_receive {:DOWN, ^ref, :process, ^distributor, reason} when reason in [:normal, :noproc], 5_000
   end
 
   test "re-adoption failure leaves the placeholder covering the tag and demand recruitment as the fallback" do

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -265,7 +265,9 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       ref = Process.monitor(pid)
 
       assert_receive {:apply_tsl_delta, _delta, 42}, 2_000
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+      # :noproc if the distributor exited before the monitor attached; the
+      # stopped telemetry below still confirms a normal exit.
+      assert_receive {:DOWN, ^ref, :process, ^pid, reason} when reason in [:normal, :noproc], 2_000
       assert_receive {:telemetry, [:bedrock, :distributor, :stopped], %{}, %{epoch: 42, reason: :normal}}, 2_000
     end
 

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -667,7 +667,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       wait_for_health_report(worker_id, pid)
 
       # Test timeout scenarios - should either succeed or timeout gracefully
-      result = GenServer.call(pid, {:info, :kind}, 1)
+      result =
+        try do
+          GenServer.call(pid, {:info, :kind}, 1)
+        catch
+          :exit, {:timeout, _} -> :timeout
+        end
 
       case result do
         {:ok, :materializer} -> :ok


### PR DESCRIPTION
## Summary

Three timing-sensitive tests each failed one recent develop CI run, always on the OTP 27.2 / Elixir 1.17.3 matrix job (the slowest). In every failing log the product behaved correctly — the test's synchronization lost a race. This PR fixes the test-code races with minimal changes; no product code is touched.

- **`distributor/server_test.exs`** (run 29548302754): `Process.monitor` is attached after the distributor starts; when the sweep delta is rejected quickly the distributor exits before the monitor attaches, so the `:DOWN` arrives with `:noproc` instead of `:normal`. The DOWN assertion now accepts either; the `stopped` telemetry assertion still verifies the exit reason was `:normal`.
- **`distributor/readoption_test.exs`** (run 29447945622): `:sys.get_state(distributor)` raced with the distributor stopping normally — the test's expected outcome. Dropped the `get_state` (the placeholder-vs-adopted pid distinction is covered by the earlier sweep/re-adoption test) and applied the same `:noproc` guard to the DOWN.
- **`olivine/genserver_integration_test.exs`** (run 29548013855): a 1 ms `GenServer.call` intended to "succeed or timeout gracefully" wasn't wrapped, so a real timeout on a slow runner crashed the test. Now caught, falling through to the existing process-survives assertion.

## Testing

- All 44 tests in the three affected files pass locally.
- `mix format --check-formatted` and `mix credo` clean on the changed files.

Closes bedrock-yp2.