### PR TITLE
Exclude globally-aborted transactions from metadata accumulation (bedrock-q67.17)

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -185,6 +185,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   the window itself is handed to the caller's `metadata_merge_fn` (defaults to a no-op)
   for in-order merging into structured metadata state.
 
+  With SHARDED resolvers accumulation is deferred: no resolver knows the merged global
+  abort set at resolution time, so metadata-carrying batch versions are held
+  (`metadata_hold`), the batch's globally-committed metadata is reported through
+  `metadata_deferred_fn`, and the caller re-sends it as `metadata_confirms` on
+  subsequent calls until resolver windows confirm it was folded in (see
+  `Bedrock.DataPlane.Resolver`).
+
   ## Parameters
 
     - `batch`: Transaction batch with commit version details from the sequencer
@@ -211,6 +218,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             resolver_fn: resolver_fn(),
             metadata_ack: Resolver.metadata_ack(),
             metadata_merge_fn: (Resolver.metadata_window() -> :ok),
+            metadata_confirms: [{Bedrock.version(), metadata_mutations()}],
+            metadata_deferred_fn: (Bedrock.version(), metadata_mutations() -> :ok),
             batch_log_push_fn: log_push_batch_fn(),
             abort_reply_fn: abort_reply_fn(),
             success_reply_fn: success_reply_fn(),
@@ -309,7 +318,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, _aborted, metadata_window} ->
-        plan = apply_metadata_window(plan, metadata_window, opts)
+        plan = apply_metadata_window(plan, metadata_window, [], opts)
         split_and_notify_aborts_with_set(plan, MapSet.new(), opts)
 
       {:error, reason} ->
@@ -346,7 +355,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
          ) do
       {:ok, aborted, metadata_window} ->
         aborted_set = MapSet.new(aborted)
-        plan = apply_metadata_window(plan, metadata_window, opts)
+        plan = apply_metadata_window(plan, metadata_window, [], opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -355,9 +364,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   end
 
   # Sharded multi-resolver path
-  # Note: In sharded mode every resolver receives the FULL metadata_per_tx
-  # (metadata is not sharded), so each maintains a duplicate accumulator and
-  # their reply windows are merged conservatively below.
+  #
+  # Each resolver only sees its own shard's conflicts, so no resolver can know
+  # the GLOBAL abort set at resolution time - metadata accumulation is
+  # deferred (bedrock-q67.17). No metadata_per_tx is sent; instead the call
+  # carries `metadata_hold: true` when this batch has metadata (each resolver
+  # marks the version as held, capping its windows below it) plus
+  # `metadata_confirms` - committed metadata from earlier batches, filtered by
+  # the merged global abort set, which the proxy re-sends on every call until
+  # the resolvers' windows confirm it was folded in. The batch's own committed
+  # metadata is reported to the proxy server via `metadata_deferred_fn` for
+  # confirmation on subsequent calls, and applied to THIS batch's routing data
+  # locally (same-batch visibility, as in single-resolver mode).
   def resolve_conflicts(
         %FinalizationPlan{stage: :ready_for_resolution} = plan,
         epoch,
@@ -393,9 +411,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
         {txn_map, metadata_list}
       end
 
+    has_metadata? = Enum.any?(metadata_per_tx, &(&1 != []))
+    opts = Keyword.put(opts, :metadata_hold, has_metadata?)
+
     case call_all_resolvers_with_map(
            resolver_transaction_map,
-           metadata_per_tx,
            epoch,
            plan.last_commit_version,
            plan.commit_version,
@@ -403,7 +423,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, aborted_set, metadata_window} ->
-        plan = apply_metadata_window(plan, metadata_window, opts)
+        local_entries = deferred_metadata_entries(plan, metadata_per_tx, aborted_set, has_metadata?, opts)
+        plan = apply_metadata_window(plan, metadata_window, local_entries, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -411,9 +432,40 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end
   end
 
-  @spec apply_metadata_window(FinalizationPlan.t(), Resolver.metadata_window(), keyword()) ::
-          FinalizationPlan.t()
-  defp apply_metadata_window(plan, metadata_window, opts) do
+  # Filters this batch's metadata by the merged GLOBAL abort set, reports it
+  # through metadata_deferred_fn (so the proxy server re-sends it as a
+  # confirmation on subsequent calls - even when empty, so resolvers release
+  # the hold), and returns it as entries for same-batch routing application.
+  @spec deferred_metadata_entries(
+          FinalizationPlan.t(),
+          [metadata_mutations()],
+          MapSet.t(non_neg_integer()),
+          boolean(),
+          keyword()
+        ) :: [MetadataAccumulator.entry()]
+  defp deferred_metadata_entries(_plan, _metadata_per_tx, _aborted_set, false, _opts), do: []
+
+  defp deferred_metadata_entries(plan, metadata_per_tx, aborted_set, true, opts) do
+    committed_metadata = MetadataAccumulator.committed_mutations(metadata_per_tx, aborted_set)
+
+    metadata_deferred_fn = Keyword.get(opts, :metadata_deferred_fn, fn _version, _mutations -> :ok end)
+    metadata_deferred_fn.(plan.commit_version, committed_metadata)
+
+    if committed_metadata == [], do: [], else: [{plan.commit_version, committed_metadata}]
+  end
+
+  # `local_entries` are this batch's own committed metadata (sharded mode) -
+  # applied to the batch's routing data for same-batch visibility, but NOT to
+  # the structured metadata state, which is fed strictly by resolver windows
+  # (keeping ack semantics intact). Single-resolver callers pass [] - their
+  # batch's metadata arrives inside the window itself.
+  @spec apply_metadata_window(
+          FinalizationPlan.t(),
+          Resolver.metadata_window(),
+          [MetadataAccumulator.entry()],
+          keyword()
+        ) :: FinalizationPlan.t()
+  defp apply_metadata_window(plan, metadata_window, local_entries, opts) do
     entries =
       case metadata_window do
         nil -> []
@@ -437,7 +489,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       replication_factor: plan.replication_factor
     }
 
-    updated_routing_data = RoutingData.apply_mutations(routing_data, entries)
+    # Window entries precede this batch's own (higher-version) local entries.
+    updated_routing_data = RoutingData.apply_mutations(routing_data, entries ++ local_entries)
 
     %{
       plan
@@ -448,24 +501,17 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     }
   end
 
+  # Sharded calls carry no metadata_per_tx (accumulation is deferred; see
+  # resolve_conflicts above), so resolvers are called with [].
   @spec call_all_resolvers_with_map(
           %{Resolver.ref() => [Transaction.encoded()]},
-          [metadata_mutations()],
           Bedrock.epoch(),
           Bedrock.version(),
           Bedrock.version(),
           [{start_key :: Bedrock.key(), Resolver.ref()}],
           keyword()
         ) :: {:ok, MapSet.t(non_neg_integer()), Resolver.metadata_window()} | {:error, term()}
-  defp call_all_resolvers_with_map(
-         resolver_transaction_map,
-         metadata_per_tx,
-         epoch,
-         last_version,
-         commit_version,
-         resolvers,
-         opts
-       ) do
+  defp call_all_resolvers_with_map(resolver_transaction_map, epoch, last_version, commit_version, resolvers, opts) do
     async_stream_fn = Keyword.get(opts, :async_stream_fn, &Task.async_stream/3)
     timeout = Keyword.get(opts, :timeout, 5_000)
 
@@ -474,7 +520,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       fn {_start_key, ref} ->
         # Every resolver must have transactions after task processing
         filtered_transactions = Map.fetch!(resolver_transaction_map, ref)
-        call_resolver_with_retry(ref, epoch, last_version, commit_version, filtered_transactions, metadata_per_tx, opts)
+        call_resolver_with_retry(ref, epoch, last_version, commit_version, filtered_transactions, [], opts)
       end,
       timeout: timeout
     )
@@ -490,18 +536,33 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end)
   end
 
-  # Sharded resolvers each see the full metadata_per_tx and maintain
-  # independent accumulators, so their windows largely duplicate one another.
-  # Merge conservatively: entries sorted by version (the proxy's per-entry
-  # version guard makes duplicates no-ops) and the WEAKEST coverage claim
-  # (max from_version) so that a gap at any resolver is still detected.
+  # Sharded resolvers each maintain independent (largely duplicate) metadata
+  # accumulators, so their windows are merged conservatively: the WEAKEST
+  # coverage claims on both ends - max from_version (a gap at any resolver is
+  # still detected) and MIN to_version (the ack derived from the merged window
+  # must not exceed what every resolver has actually served; their settled
+  # floors can differ transiently under deferred confirmation). Entries at the
+  # same version are identical by construction (one entry per batch version,
+  # broadcast to all resolvers), so they are deduplicated by version, and
+  # entries beyond the merged to_version are truncated - they will be
+  # re-served once every resolver has settled past them. A resolver returns
+  # nil only when its settled floor has reached its last_version, so nil
+  # replies never mask a lower settled floor here.
   @spec merge_metadata_windows(Resolver.metadata_window(), Resolver.metadata_window()) :: Resolver.metadata_window()
   defp merge_metadata_windows(nil, window), do: window
   defp merge_metadata_windows(window, nil), do: window
 
   defp merge_metadata_windows({from_a, to_a, entries_a}, {from_b, to_b, entries_b}) do
     from = if from_a == nil, do: from_b, else: if(from_b == nil, do: from_a, else: max(from_a, from_b))
-    {from, max(to_a, to_b), Enum.sort_by(entries_a ++ entries_b, &elem(&1, 0))}
+    to = min(to_a, to_b)
+
+    entries =
+      (entries_a ++ entries_b)
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.dedup_by(&elem(&1, 0))
+      |> Enum.take_while(fn {version, _} -> version <= to end)
+
+    {from, to, entries}
   end
 
   @spec call_resolver_with_retry(
@@ -533,11 +594,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     # to a timeout is simply re-sent by the resolver - no window is ever skipped.
     metadata_ack = Keyword.get(opts, :metadata_ack, {self(), nil})
 
+    # Deferred-metadata directives (sharded mode; see resolve_conflicts).
+    # Retried calls re-carry them: holds and confirms are idempotent.
+    metadata_hold = Keyword.get(opts, :metadata_hold, false)
+    metadata_confirms = Keyword.get(opts, :metadata_confirms, [])
+
     timeout_in_ms = timeout_fn.(attempts_used)
 
     case resolver_fn.(ref, epoch, last_version, commit_version, filtered_transactions, metadata_per_tx,
            timeout: timeout_in_ms,
-           metadata_ack: metadata_ack
+           metadata_ack: metadata_ack,
+           metadata_hold: metadata_hold,
+           metadata_confirms: metadata_confirms
          ) do
       {:ok, _, _} = success ->
         success

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -225,20 +225,21 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     maybe_set_empty_transaction_timeout(%{t | batch: nil})
   end
 
-  def handle_info({:routing_data_update, updated_routing_data}, %{mode: :running} = t) do
-    noreply(%{t | routing_data: updated_routing_data}, timeout: t.empty_transaction_timeout_ms)
-  end
-
   def handle_info({:routing_data_update, updated_routing_data}, t) do
-    noreply(%{t | routing_data: updated_routing_data})
-  end
-
-  def handle_info({:metadata_updates, window}, %{mode: :running} = t) do
-    noreply(apply_metadata_window(t, window), timeout: t.empty_transaction_timeout_ms)
+    noreply_resuming_cadence(%{t | routing_data: updated_routing_data})
   end
 
   def handle_info({:metadata_updates, window}, t) do
-    noreply(apply_metadata_window(t, window))
+    noreply_resuming_cadence(apply_metadata_window(t, window))
+  end
+
+  # A sharded finalization task reports its batch's committed metadata
+  # (already filtered by the merged GLOBAL abort set). It is re-sent to the
+  # resolvers as a confirmation on every subsequent call until their windows
+  # ack past its version (see apply_metadata_window/2). Tasks race to this
+  # mailbox, so insert in version order.
+  def handle_info({:metadata_deferred, version, mutations}, t) do
+    noreply_resuming_cadence(add_deferred_metadata(t, version, mutations))
   end
 
   def handle_info({:DOWN, _ref, :process, director_pid, _reason}, %{director: director_pid} = t) do
@@ -259,7 +260,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       sequencer: sequencer,
       resolver_layout: resolver_layout,
       routing_data: routing_data,
-      metadata: %{version: applied_metadata_version}
+      metadata: %{version: applied_metadata_version},
+      deferred_metadata: deferred_metadata
     } = state
 
     Task.start_link(fn ->
@@ -274,7 +276,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
              # the metadata version this proxy has confirmed applying - the
              # resolver keys its progress and differential windows off this.
              metadata_ack: {server_pid, applied_metadata_version},
-             metadata_merge_fn: fn window -> send(server_pid, {:metadata_updates, window}) end
+             metadata_merge_fn: fn window -> send(server_pid, {:metadata_updates, window}) end,
+             # Deferred-metadata confirmations for sharded resolvers: committed
+             # metadata from earlier batches, re-sent until acked via windows.
+             metadata_confirms: deferred_metadata,
+             metadata_deferred_fn: fn version, mutations ->
+               send(server_pid, {:metadata_deferred, version, mutations})
+             end
            ) do
         {:ok, _n_aborts, _n_oks, updated_routing_data} ->
           send(server_pid, {:routing_data_update, updated_routing_data})
@@ -319,7 +327,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     # windows keep this monotone.
     version = if metadata.version == nil or to_version > metadata.version, do: to_version, else: metadata.version
 
-    %{t | metadata: %{metadata | version: version}}
+    # A window covering a deferred version proves every resolver folded that
+    # confirmation in (in sharded mode the merged to_version is the MINIMUM
+    # settled version across resolvers) - stop re-sending it.
+    deferred_metadata = Enum.drop_while(t.deferred_metadata, fn {v, _mutations} -> v <= version end)
+
+    %{t | metadata: %{metadata | version: version}, deferred_metadata: deferred_metadata}
+  end
+
+  @spec add_deferred_metadata(State.t(), Bedrock.version(), [term()]) :: State.t()
+  defp add_deferred_metadata(t, version, mutations) do
+    {earlier, later} = Enum.split_while(t.deferred_metadata, fn {v, _} -> v < version end)
+    %{t | deferred_metadata: earlier ++ [{version, mutations} | later]}
   end
 
   @spec reply_fn(GenServer.from()) :: Batch.reply_fn()
@@ -332,6 +351,17 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     do: noreply(t, timeout: t.empty_transaction_timeout_ms)
 
   defp maybe_set_empty_transaction_timeout(t), do: noreply(t)
+
+  # Info messages cancel any pending GenServer timeout, so restore the right
+  # cadence: an OPEN batch is waiting on a zero timeout to flush (losing it
+  # would strand the batch - and its blocked callers - until the next
+  # message), otherwise resume the empty-transaction heartbeat.
+  @spec noreply_resuming_cadence(State.t()) :: {:noreply, State.t(), timeout()} | {:noreply, State.t()}
+  defp noreply_resuming_cadence(%{mode: :running, batch: nil} = t),
+    do: noreply(t, timeout: t.empty_transaction_timeout_ms)
+
+  defp noreply_resuming_cadence(%{mode: :running} = t), do: noreply(t, timeout: 0)
+  defp noreply_resuming_cadence(t), do: noreply(t)
 
   @spec abort_current_batch(State.t()) :: :ok
   defp abort_current_batch(%{batch: nil}), do: :ok

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -21,7 +21,8 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           mode: mode(),
           lock_token: binary(),
           routing_data: RoutingData.t() | nil,
-          metadata: Metadata.t()
+          metadata: Metadata.t(),
+          deferred_metadata: [{Bedrock.version(), [term()]}]
         }
   defstruct cluster: nil,
             director: nil,
@@ -35,5 +36,9 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             mode: :locked,
             lock_token: nil,
             routing_data: nil,
-            metadata: %Metadata{}
+            metadata: %Metadata{},
+            # Committed metadata from sharded batches (version-ascending),
+            # re-sent as confirmations on every resolver call until the
+            # resolvers' windows show it was folded in (ack >= version).
+            deferred_metadata: []
 end

--- a/lib/bedrock/data_plane/resolver.ex
+++ b/lib/bedrock/data_plane/resolver.ex
@@ -23,6 +23,22 @@ defmodule Bedrock.DataPlane.Resolver do
   progress only advances via acks, lost replies are re-sent on the proxy's
   next call and concurrent in-flight windows overlap (out-of-order arrival at
   the proxy is lossless).
+
+  ## Deferred Metadata (sharded resolvers)
+
+  With sharded resolvers each resolver only sees its own shard's conflicts,
+  so a locally-committed transaction can still be aborted globally (by
+  another shard's resolver). Metadata accumulation is therefore DEFERRED in
+  sharded mode: the proxy sends no `metadata_per_tx`, instead passing
+  `metadata_hold: true` when the batch carries metadata (the resolver marks
+  the batch version as held) and `metadata_confirms` - `{version, mutations}`
+  pairs for earlier held batches, already filtered by the proxy's merged
+  GLOBAL abort set - which the resolver folds into its window at the original
+  commit versions. Windows never extend past the oldest still-held version,
+  so no proxy can ack past metadata that has yet to be confirmed - version
+  order is preserved even when confirmations arrive out of order. Held
+  versions a proxy never confirms (it died mid-batch) expire with the version
+  retention horizon.
   """
 
   alias Bedrock.DataPlane.Resolver.MetadataAccumulator
@@ -50,6 +66,15 @@ defmodule Bedrock.DataPlane.Resolver do
            entries :: [MetadataAccumulator.entry()]}
           | nil
 
+  @typedoc """
+  Deferred-metadata directives for sharded mode: whether this batch's
+  metadata must be held pending global-abort confirmation, plus confirmations
+  (globally-filtered committed mutations at their original commit versions)
+  for earlier held batches.
+  """
+  @type metadata_directives ::
+          {hold? :: boolean(), confirms :: [{Bedrock.version(), metadata_mutations()}]}
+
   @spec resolve_transactions(
           ref(),
           epoch :: Bedrock.epoch(),
@@ -57,7 +82,12 @@ defmodule Bedrock.DataPlane.Resolver do
           commit_version :: Bedrock.version(),
           [Transaction.encoded()],
           metadata_per_tx :: [metadata_mutations()],
-          opts :: [timeout: Bedrock.timeout_in_ms(), metadata_ack: metadata_ack()]
+          opts :: [
+            timeout: Bedrock.timeout_in_ms(),
+            metadata_ack: metadata_ack(),
+            metadata_hold: boolean(),
+            metadata_confirms: [{Bedrock.version(), metadata_mutations()}]
+          ]
         ) ::
           {:ok, aborted :: [transaction_index :: non_neg_integer()], metadata_window()}
           | {:failure, :timeout, ref()}
@@ -65,6 +95,7 @@ defmodule Bedrock.DataPlane.Resolver do
   def resolve_transactions(ref, epoch, last_version, commit_version, transaction_summaries, metadata_per_tx, opts \\ []) do
     timeout = opts[:timeout] || :infinity
     metadata_ack = opts[:metadata_ack] || {self(), nil}
+    metadata_directives = {opts[:metadata_hold] || false, opts[:metadata_confirms] || []}
 
     :telemetry.span(
       [:bedrock, :data_plane, :resolver, :call, :resolve_transactions],
@@ -80,7 +111,7 @@ defmodule Bedrock.DataPlane.Resolver do
         ref
         |> GenServer.call(
           {:resolve_transactions, epoch, {last_version, commit_version}, transaction_summaries, metadata_per_tx,
-           metadata_ack},
+           metadata_ack, metadata_directives},
           timeout
         )
         |> case do

--- a/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
+++ b/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
@@ -66,6 +66,51 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
   end
 
   @doc """
+  Flattens per-transaction metadata mutations, keeping only transactions that
+  survived the abort set (indices are batch positions), in transaction order.
+
+  Shared by immediate accumulation (resolver, local abort set) and deferred
+  confirmation (commit proxy, merged global abort set) so both sides agree on
+  which mutations a batch committed.
+
+  ## Examples
+
+      iex> committed_mutations([[{:set, <<0xFF, "a">>, "1"}], [{:set, <<0xFF, "b">>, "2"}]], MapSet.new([1]))
+      [{:set, <<0xFF, "a">>, "1"}]
+  """
+  @spec committed_mutations([[mutation()]], MapSet.t(non_neg_integer())) :: [mutation()]
+  def committed_mutations(metadata_per_tx, aborted_set) do
+    metadata_per_tx
+    |> Enum.with_index()
+    |> Enum.reject(fn {_mutations, idx} -> MapSet.member?(aborted_set, idx) end)
+    |> Enum.flat_map(fn {mutations, _idx} -> mutations end)
+  end
+
+  @doc """
+  Inserts mutations at a given version, maintaining version order even when
+  the version is older than existing entries.
+
+  Used for deferred (confirmed-later) metadata in sharded-resolver mode, where
+  confirmations for different versions can arrive out of order. If mutations
+  is empty, this is a no-op.
+
+  ## Examples
+
+      iex> acc = new()
+      iex>   |> append(v(2), [{:set, <<0xFF, "b">>, "2"}])
+      iex>   |> insert_sorted(v(1), [{:set, <<0xFF, "a">>, "1"}])
+      iex> Enum.map(entries(acc), &elem(&1, 0))
+      [<<0, 0, 0, 0, 0, 0, 0, 1>>, <<0, 0, 0, 0, 0, 0, 0, 2>>]
+  """
+  @spec insert_sorted(t(), Bedrock.version(), [mutation()]) :: t()
+  def insert_sorted(accumulator, _version, []), do: accumulator
+
+  def insert_sorted(%__MODULE__{reversed_entries: reversed} = accumulator, version, mutations) do
+    {newer, older} = Enum.split_while(reversed, fn {v, _} -> v > version end)
+    %{accumulator | reversed_entries: newer ++ [{version, mutations} | older]}
+  end
+
+  @doc """
   Returns all mutations since (but not including) the given version.
 
   Returns mutations in version order (oldest first). If `since_version` is nil,

--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -107,7 +107,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata, _ack},
+        {:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata, _ack, _directives},
         _from,
         t
       )
@@ -117,7 +117,8 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack,
+         metadata_directives},
         from,
         t
       )
@@ -129,7 +130,9 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> case do
       :ok ->
         noreply(t,
-          continue: {:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn(from)}}
+          continue:
+            {:process_ready,
+             {next_version, transactions, metadata_per_tx, metadata_ack, metadata_directives, reply_fn(from)}}
         )
 
       {:error, reason} ->
@@ -140,7 +143,8 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack,
+         metadata_directives},
         from,
         t
       )
@@ -151,7 +155,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> Validation.check_transactions()
     |> case do
       :ok ->
-        data = {next_version, transactions, metadata_per_tx, metadata_ack}
+        data = {next_version, transactions, metadata_per_tx, metadata_ack, metadata_directives}
 
         {new_waiting, _timeout} =
           WaitingList.insert(
@@ -174,14 +178,19 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, _next_version}, transactions, _metadata, metadata_ack},
+        {:resolve_transactions, epoch, {last_version, _next_version}, transactions, _metadata, metadata_ack,
+         {_hold?, confirms}},
         _from,
         t
       )
       when t.mode == :running and epoch == t.epoch and is_binary(last_version) and last_version < t.last_version do
-    # All transactions aborted due to stale version - return a differential metadata window for the proxy
-    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
-    aborted_indices = Enum.to_list(0..(length(transactions) - 1))
+    # All transactions aborted due to stale version - return a differential
+    # metadata window for the proxy. This is a retry of an already-processed
+    # batch, so any hold was recorded then (re-holding a confirmed version
+    # would wedge it) - but its confirms may be new; apply them (idempotent).
+    {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
+    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
+    aborted_indices = Enum.to_list(0..(length(transactions) - 1)//1)
     reply(t, {:ok, aborted_indices, metadata_window})
   end
 
@@ -206,18 +215,32 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_continue({:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn}}, t) do
+  def handle_continue(
+        {:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, {hold?, confirms}, reply_fn}},
+        t
+      ) do
     emit_processing(transactions, next_version)
 
     {conflicts, aborted} = resolve(t.conflicts, transactions, next_version)
     t = %{t | conflicts: conflicts, last_version: next_version}
     emit_completed(transactions, aborted, next_version)
 
-    # Accumulate metadata from non-aborted transactions
-    t = accumulate_committed_metadata(t, next_version, metadata_per_tx, aborted)
+    # Fold in confirmed deferred metadata, then either hold this batch
+    # (sharded mode - accumulation deferred until the proxy confirms against
+    # the merged GLOBAL abort set; any metadata_per_tx is ignored so immediate
+    # and deferred accumulation can never double-apply) or accumulate
+    # immediately (single-resolver mode - the local abort set IS global).
+    {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
+
+    t =
+      if hold? do
+        %{t | held_metadata_versions: MapSet.put(t.held_metadata_versions, next_version)}
+      else
+        accumulate_committed_metadata(t, next_version, metadata_per_tx, aborted)
+      end
 
     # Get the differential window for this proxy and record its confirmed progress
-    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
+    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
 
     reply_fn.({:ok, aborted, metadata_window})
     emit_reply_sent(transactions, aborted, next_version)
@@ -226,11 +249,11 @@ defmodule Bedrock.DataPlane.Resolver.Server do
       {updated_waiting, nil} ->
         noreply(%{t | waiting: updated_waiting}, continue: :next_timeout)
 
-      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata_per_tx, metadata_ack}}} ->
+      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata, ack, directives}}} ->
         emit_waiting_resolved(transactions, [], waiting_next_version)
 
         noreply(%{t | waiting: updated_waiting},
-          continue: {:process_ready, {waiting_next_version, transactions, metadata_per_tx, metadata_ack, reply_fn}}
+          continue: {:process_ready, {waiting_next_version, transactions, metadata, ack, directives, reply_fn}}
         )
     end
   end
@@ -272,39 +295,81 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   # Accumulates metadata mutations from committed (non-aborted) transactions
   @spec accumulate_committed_metadata(State.t(), Bedrock.version(), [[tuple()]], [non_neg_integer()]) :: State.t()
   defp accumulate_committed_metadata(t, commit_version, metadata_per_tx, aborted) do
-    aborted_set = MapSet.new(aborted)
-
     metadata_per_tx
-    |> Enum.with_index()
-    |> Enum.reject(fn {_mutations, idx} -> MapSet.member?(aborted_set, idx) end)
-    |> Enum.flat_map(fn {mutations, _idx} -> mutations end)
+    |> MetadataAccumulator.committed_mutations(MapSet.new(aborted))
     |> case do
       [] -> t
       mutations -> %{t | metadata_window: MetadataAccumulator.append(t.metadata_window, commit_version, mutations)}
     end
   end
 
+  # Folds confirmed deferred metadata (already filtered by the proxy's merged
+  # GLOBAL abort set) into the window at the original commit versions.
+  # Confirmations for different held versions can arrive out of order, so the
+  # insert is sorted; the settled-version cap below guarantees no proxy has
+  # been served (or acked) past any still-held version, so a late insert is
+  # never behind anyone's ack. Idempotent: only still-held versions apply, so
+  # a retried call re-carrying confirms is a no-op. Returns whether any hold
+  # was released (derived from the held-set delta).
+  @spec apply_metadata_confirms(State.t(), [{Bedrock.version(), [tuple()]}]) ::
+          {State.t(), confirmed_any? :: boolean()}
+  defp apply_metadata_confirms(t, confirms) do
+    updated =
+      Enum.reduce(confirms, t, fn {version, mutations}, t ->
+        if MapSet.member?(t.held_metadata_versions, version) do
+          %{
+            t
+            | metadata_window: MetadataAccumulator.insert_sorted(t.metadata_window, version, mutations),
+              held_metadata_versions: MapSet.delete(t.held_metadata_versions, version)
+          }
+        else
+          t
+        end
+      end)
+
+    {updated, updated.held_metadata_versions != t.held_metadata_versions}
+  end
+
+  # The highest version whose metadata is fully settled: everything at or
+  # below it is either accumulated or known metadata-free. Held (deferred,
+  # unconfirmed) versions cap it - windows must never let a proxy ack past
+  # metadata that could still be confirmed later.
+  @spec settled_version(State.t()) :: Bedrock.version()
+  defp settled_version(%{held_metadata_versions: held, last_version: last_version}) do
+    case Enum.min(held, fn -> nil end) do
+      nil -> last_version
+      oldest_held -> Version.subtract(oldest_held, 1)
+    end
+  end
+
   # Builds the differential metadata window for a proxy and records its
   # confirmed progress.
   #
-  # The window covers (from, t.last_version] where `from` is the version the
-  # proxy has CONFIRMED applying (its ack). Progress advances only via acks, so
-  # a reply lost to a call timeout is simply re-sent on the proxy's next call,
-  # and windows to concurrently in-flight batches overlap - out-of-order
-  # arrival at the proxy is lossless (its per-entry version guard skips
-  # already-applied entries).
+  # The window covers (from, settled] where `from` is the version the proxy
+  # has CONFIRMED applying (its ack) and `settled` is last_version except when
+  # deferred metadata is still held (see settled_version/1). Progress advances
+  # only via acks, so a reply lost to a call timeout is simply re-sent on the
+  # proxy's next call, and windows to concurrently in-flight batches overlap -
+  # out-of-order arrival at the proxy is lossless (its per-entry version guard
+  # skips already-applied entries).
   #
-  # If pruning has discarded entries the proxy never confirmed (only possible
-  # after the proxy was expired from proxy_progress), the window's
-  # from_version is the pruned floor - above the proxy's applied version -
-  # which the proxy detects as an unrecoverable coverage gap.
-  @spec get_metadata_window_for_proxy(State.t(), Resolver.metadata_ack()) ::
+  # If pruning (or a held-version expiry) has discarded coverage the proxy
+  # never confirmed, the window's from_version is the pruned floor - above the
+  # proxy's applied version - which the proxy detects as an unrecoverable
+  # coverage gap.
+  #
+  # A window is nil only when there is nothing to report AND settled has
+  # reached last_version: while metadata is held (or when this call released a
+  # hold), even an empty window is returned so the merged to_version at the
+  # proxy honestly reflects this resolver's settled floor and confirmed holds
+  # advance the proxy's ack (letting it stop re-sending confirmations).
+  @spec get_metadata_window_for_proxy(State.t(), Resolver.metadata_ack(), confirmed_any? :: boolean()) ::
           {Resolver.metadata_window(), State.t()}
-  defp get_metadata_window_for_proxy(t, {proxy_id, acked}) do
+  defp get_metadata_window_for_proxy(t, {proxy_id, acked}, confirmed_any?) do
     t =
       t
       |> record_proxy_progress(proxy_id, acked)
-      |> expire_stale_proxies()
+      |> expire_stale()
       |> prune_metadata_window()
 
     # Serve the differential from the RECORDED (monotone) ack: a retried call
@@ -317,12 +382,27 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     floor = t.metadata_pruned_through
     gap? = floor != nil and (acked == nil or acked < floor)
     from = if gap?, do: floor, else: acked
-    entries = MetadataAccumulator.mutations_since(t.metadata_window, from)
+    settled = settled_version(t)
 
-    window = if entries == [] and not gap?, do: nil, else: {from, t.last_version, entries}
+    # Entries above the settled floor (confirmed while an older version is
+    # still held) are withheld until everything below them settles.
+    entries =
+      t.metadata_window
+      |> MetadataAccumulator.mutations_since(from)
+      |> withhold_unsettled(settled, t.last_version)
+
+    window =
+      if entries == [] and not gap? and not confirmed_any? and settled == t.last_version,
+        do: nil,
+        else: {from, settled, entries}
 
     {window, t}
   end
+
+  # Fast path: with no held versions, settled == last_version and no entry can
+  # exceed it.
+  defp withhold_unsettled(entries, settled, last_version) when settled == last_version, do: entries
+  defp withhold_unsettled(entries, settled, _), do: Enum.take_while(entries, fn {version, _} -> version <= settled end)
 
   @spec record_proxy_progress(State.t(), pid(), Bedrock.version() | nil) :: State.t()
   defp record_proxy_progress(t, proxy_id, acked) do
@@ -339,18 +419,36 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   defp max_ack(prev, nil), do: prev
   defp max_ack(prev, acked), do: max(prev, acked)
 
-  # Drops proxies not seen within the version retention horizon so a dead (or
-  # pathologically stalled) proxy neither leaks a progress entry nor blocks
-  # window pruning forever. A live proxy calls at least once per empty-batch
-  # interval, far inside the horizon.
-  @spec expire_stale_proxies(State.t()) :: State.t()
-  defp expire_stale_proxies(t) do
+  # Expires state older than the version retention horizon:
+  #
+  # - Proxies not seen within the horizon are dropped so a dead (or
+  #   pathologically stalled) proxy neither leaks a progress entry nor blocks
+  #   window pruning forever. A live proxy calls at least once per empty-batch
+  #   interval, far inside the horizon.
+  # - Held (deferred, unconfirmed) metadata versions older than the horizon
+  #   are dropped so an unconfirmed hold cannot cap window distribution
+  #   forever. A hold this old is an invariant breach - its proxy stopped
+  #   confirming (it died mid-batch, or is stalled beyond any healthy cadence)
+  #   and the metadata MAY have committed - so the expired version is folded
+  #   into metadata_pruned_through: every proxy acked below it (necessarily
+  #   all of them, since holds cap acks) takes the coverage-gap fail-fast exit
+  #   into director-driven recovery, which rebuilds metadata from durable
+  #   state, rather than silently missing possibly-committed metadata.
+  @spec expire_stale(State.t()) :: State.t()
+  defp expire_stale(t) do
     case retention_cutoff(t) do
       nil ->
         t
 
       cutoff ->
-        %{t | proxy_progress: Map.filter(t.proxy_progress, fn {_pid, {_acked, seen}} -> seen >= cutoff end)}
+        {expired_holds, live_holds} = MapSet.split_with(t.held_metadata_versions, &(&1 < cutoff))
+
+        %{
+          t
+          | proxy_progress: Map.filter(t.proxy_progress, fn {_pid, {_acked, seen}} -> seen >= cutoff end),
+            held_metadata_versions: live_holds,
+            metadata_pruned_through: max_ack(t.metadata_pruned_through, Enum.max(expired_holds, fn -> nil end))
+        }
     end
   end
 

--- a/lib/bedrock/data_plane/resolver/state.ex
+++ b/lib/bedrock/data_plane/resolver/state.ex
@@ -24,6 +24,11 @@ defmodule Bedrock.DataPlane.Resolver.State do
     pruning (nil if no entry has been discarded). A proxy whose ack falls
     below this floor can no longer be served a complete differential; a proxy
     acked at or above it has confirmed every discarded entry.
+  - `held_metadata_versions` - Batch versions whose metadata is deferred
+    pending global-abort confirmation from the submitting proxy (sharded
+    mode). Windows never extend past the oldest held version; held versions
+    older than the retention horizon are expired (their proxy died - the
+    epoch is being recovered).
   """
 
   alias Bedrock.DataPlane.Resolver.Conflicts
@@ -47,7 +52,8 @@ defmodule Bedrock.DataPlane.Resolver.State do
             pid() => {acked :: Bedrock.version() | nil, last_seen :: Bedrock.version()}
           },
           metadata_window: MetadataAccumulator.t(),
-          metadata_pruned_through: Bedrock.version() | nil
+          metadata_pruned_through: Bedrock.version() | nil,
+          held_metadata_versions: MapSet.t(Bedrock.version())
         }
   defstruct conflicts: nil,
             oldest_version: nil,
@@ -62,5 +68,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
             last_sweep_time: nil,
             proxy_progress: %{},
             metadata_window: nil,
-            metadata_pruned_through: nil
+            metadata_pruned_through: nil,
+            held_metadata_versions: MapSet.new()
 end

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -158,6 +158,104 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       assert_receive {:tx1, {:error, :aborted}}
     end
 
+    test "defers metadata: resolvers get no metadata_per_tx, a hold flag, and re-sent confirmations" do
+      test_pid = self()
+      confirms = [{Version.from_integer(90), [{:set, <<0xFF, "k">>, "v"}]}]
+
+      metadata_tx =
+        Transaction.encode(%{
+          mutations: [{:set, "apple", "v0"}, {:set, <<0xFF, "/system/key">>, "meta"}],
+          write_conflicts: [{"apple", "apple" <> <<0>>}],
+          read_conflicts: nil
+        })
+
+      batch = batch_with([{reply_fn(test_pid, :tx0), metadata_tx}])
+
+      resolver_fn = fn ref, _epoch, _last, _commit, _txns, metadata_per_tx, opts ->
+        send(test_pid, {:resolver_called, ref, metadata_per_tx, opts[:metadata_hold], opts[:metadata_confirms]})
+        {:ok, [], nil}
+      end
+
+      opts =
+        base_opts(sharded_layout(), routing_data(),
+          resolver_fn: resolver_fn,
+          metadata_confirms: confirms
+        )
+
+      assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+
+      # No speculative metadata reaches any resolver; both get the hold flag
+      # (this batch carries metadata) and the proxy's pending confirmations.
+      assert_receive {:resolver_called, :resolver_a, [], true, ^confirms}
+      assert_receive {:resolver_called, :resolver_b, [], true, ^confirms}
+    end
+
+    test "reports committed metadata filtered by the MERGED global abort set via metadata_deferred_fn" do
+      test_pid = self()
+
+      metadata_tx = fn key, meta_key ->
+        Transaction.encode(%{
+          mutations: [{:set, key, "v"}, {:set, meta_key, "meta"}],
+          write_conflicts: [{key, key <> <<0>>}],
+          read_conflicts: nil
+        })
+      end
+
+      # tx0 survives; tx1 is aborted by resolver_b ONLY - resolver_a saw no
+      # conflict for it, but its metadata must still be excluded globally.
+      batch =
+        batch_with([
+          {reply_fn(test_pid, :tx0), metadata_tx.("apple", <<0xFF, "/committed">>)},
+          {reply_fn(test_pid, :tx1), metadata_tx.("zebra", <<0xFF, "/aborted">>)}
+        ])
+
+      resolver_fn = fn
+        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil}
+        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [1], nil}
+      end
+
+      metadata_deferred_fn = fn version, mutations -> send(test_pid, {:deferred, version, mutations}) end
+
+      opts =
+        base_opts(sharded_layout(), routing_data(),
+          resolver_fn: resolver_fn,
+          metadata_deferred_fn: metadata_deferred_fn
+        )
+
+      assert {:ok, 1, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+
+      assert_receive {:deferred, @commit_version, [{:set, <<0xFF, "/committed">>, "meta"}]}
+    end
+
+    test "merged metadata windows claim the weakest coverage on both ends and withhold unsettled entries" do
+      test_pid = self()
+      v = &Version.from_integer/1
+      entry_95 = {v.(95), [{:set, <<0xFF, "a">>, "1"}]}
+      entry_98 = {v.(98), [{:set, <<0xFF, "b">>, "2"}]}
+
+      # resolver_a has settled through v(99); resolver_b only through v(96)
+      # (it still holds deferred metadata). The merged window must not let the
+      # proxy ack past v(96) nor apply the entry at v(98) out of order, and
+      # the duplicate entry at v(95) (both resolvers carry it) collapses.
+      resolver_fn = fn
+        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts ->
+          {:ok, [], {v.(90), v.(99), [entry_95, entry_98]}}
+
+        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts ->
+          {:ok, [], {v.(90), v.(96), [entry_95]}}
+      end
+
+      metadata_merge_fn = fn window -> send(test_pid, {:merged_window, window}) end
+
+      opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn, metadata_merge_fn: metadata_merge_fn)
+
+      assert {:ok, 0, 0, _routing_data} = Finalization.finalize_batch(empty_batch(), opts)
+
+      from90 = v.(90)
+      to96 = v.(96)
+      assert_receive {:merged_window, {^from90, ^to96, [^entry_95]}}
+    end
+
     test "fails the batch when a resolver task exits" do
       exiting_async_stream_fn = fn _enumerable, _fun, _opts -> [{:exit, :killed}] end
 

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -31,7 +31,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
     def handle_call(
           {:resolve_transactions, _epoch, {_last_version, _next_version}, _transactions, _metadata_per_tx,
-           {_proxy_id, _acked_version}},
+           {_proxy_id, _acked_version}, {_metadata_hold?, _metadata_confirms}},
           _from,
           state
         ) do

--- a/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
@@ -1,0 +1,283 @@
+defmodule Bedrock.DataPlane.CommitProxy.ShardedMetadataDistributionIntegrationTest do
+  @moduledoc """
+  End-to-end tests for \\xFF system metadata distribution under SHARDED
+  resolvers (bedrock-q67.17).
+
+  In sharded mode each resolver only sees its own shard's conflicts, so a
+  transaction can be aborted by one resolver while every other resolver sees
+  no conflict for it. The global abort set is the union merged at the commit
+  proxy. Correctness requirements pinned here:
+
+  - metadata from a GLOBALLY-aborted transaction must never be distributed
+    (not into any resolver's window, not into any proxy's metadata);
+  - metadata from committed transactions must always be distributed;
+  - version ordering of metadata is preserved.
+
+  Uses a real Sequencer.Server, two real Resolver.Servers, and a real
+  CommitProxy.Server; only the log is faked (established seam).
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
+  alias Bedrock.DataPlane.Resolver.MetadataAccumulator
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Sequencer.Server, as: SequencerServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component) when is_atom(component), do: :"sharded_metadata_dist_test_#{component}"
+  end
+
+  # Fake log that always accepts pushes (established DI seam)
+  defmodule FakeLog do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_opts), do: GenServer.start_link(__MODULE__, %{})
+
+    def init(state), do: {:ok, state}
+
+    def handle_call({:push, _transaction, _last_commit_version}, _from, state), do: {:reply, :ok, state}
+  end
+
+  setup do
+    director = self()
+    epoch = 1
+    lock_token = :crypto.strong_rand_bytes(32)
+
+    sequencer =
+      start_supervised!(
+        {SequencerServer,
+         [
+           cluster: TestCluster,
+           otp_name: :sharded_metadata_dist_test_sequencer,
+           director: director,
+           epoch: epoch,
+           last_committed_version: Version.zero()
+         ]}
+      )
+
+    start_resolver = fn key_range ->
+      start_supervised!(
+        {ResolverServer,
+         [
+           lock_token: lock_token,
+           key_range: key_range,
+           epoch: epoch,
+           last_version: Version.zero(),
+           director: director,
+           cluster: TestCluster
+         ]},
+        id: {:resolver, key_range}
+      )
+    end
+
+    # Shard split at "m": resolver_a covers ["", "m"), resolver_b ["m", ...)
+    resolver_a = start_resolver.({"", "m"})
+    resolver_b = start_resolver.({"m", <<0xFF, 0xFF>>})
+
+    log = start_supervised!({FakeLog, []})
+
+    resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver_a}, {"m", resolver_b}]})
+
+    shard_table = :ets.new(:sharded_metadata_dist_test_shards, [:ordered_set, :public])
+    # Single storage shard (tag 0) covering the entire keyspace
+    :ets.insert(shard_table, {<<0xFF, 0xFF>>, 0})
+
+    routing_data = %RoutingData{
+      shard_table: shard_table,
+      log_map: %{0 => "log_1"},
+      log_services: %{"log_1" => log},
+      replication_factor: 1
+    }
+
+    proxy =
+      start_supervised!(
+        CommitProxyServer.child_spec(
+          cluster: TestCluster,
+          director: director,
+          epoch: epoch,
+          instance: 0,
+          max_latency_in_ms: 1,
+          max_per_batch: 10,
+          # Deferred-metadata confirmations ride SUBSEQUENT resolver calls; the
+          # tests drive those deterministically with filler commits (see
+          # commit_until/4) rather than relying on the empty-batch cadence
+          # (which :sys.get_state polling would starve by resetting the
+          # GenServer timeout).
+          empty_transaction_timeout_ms: 60_000,
+          lock_token: lock_token,
+          sequencer: sequencer,
+          resolver_layout: resolver_layout,
+          routing_data: routing_data
+        )
+      )
+
+    :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data})
+
+    %{proxy: proxy, resolver_a: resolver_a, resolver_b: resolver_b, epoch: epoch}
+  end
+
+  defp encode_tx(mutations, write_key, read_conflicts \\ []) do
+    Transaction.encode(%{
+      mutations: mutations,
+      read_conflicts: read_conflicts,
+      write_conflicts: [{write_key, write_key <> <<0>>}]
+    })
+  end
+
+  defp commit(proxy, epoch, tx), do: GenServer.call(proxy, {:commit, epoch, tx}, 5_000)
+
+  defp commit!(proxy, epoch, tx) do
+    assert {:ok, version, _index} = commit(proxy, epoch, tx)
+    version
+  end
+
+  # Drives convergence deterministically: deferred-metadata confirmations and
+  # window replies ride subsequent resolver calls, so commit filler
+  # transactions until the condition holds (application is asynchronous).
+  defp commit_until(proxy, epoch, condition_fn, attempts \\ 50)
+
+  defp commit_until(_proxy, _epoch, _condition_fn, 0), do: flunk("Condition not met before timeout")
+
+  defp commit_until(proxy, epoch, condition_fn, attempts) do
+    if condition_fn.() do
+      :ok
+    else
+      key = "filler_#{System.unique_integer([:positive])}"
+      commit!(proxy, epoch, encode_tx([{:set, key, "x"}], key))
+      Process.sleep(10)
+      commit_until(proxy, epoch, condition_fn, attempts - 1)
+    end
+  end
+
+  defp proxy_metadata(proxy), do: :sys.get_state(proxy).metadata
+
+  defp resolver_metadata_mutations(resolver) do
+    resolver
+    |> :sys.get_state()
+    |> Map.fetch!(:metadata_window)
+    |> MetadataAccumulator.entries()
+    |> Enum.flat_map(fn {_version, mutations} -> mutations end)
+  end
+
+  test "metadata from a transaction aborted by only ONE shard's resolver is never distributed", %{
+    proxy: proxy,
+    resolver_a: resolver_a,
+    resolver_b: resolver_b,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("victim")
+    encoded_tag = Values.encode_shard_key_entry(7, "")
+    metadata_mutation = {:set, shard_key, encoded_tag}
+
+    # Establish a conflicting write at "zebra" (resolver_b's shard).
+    commit!(proxy, epoch, encode_tx([{:set, "zebra", "z1"}], "zebra"))
+
+    # This transaction read "zebra" at version 0 (stale) and writes "apple"
+    # (resolver_a's shard) plus a system metadata key. Resolver B aborts it on
+    # the read conflict; resolver A sees only the "apple" write and does not.
+    # The GLOBAL outcome is abort - its metadata must never surface anywhere.
+    assert {:error, :aborted} =
+             commit(
+               proxy,
+               epoch,
+               encode_tx(
+                 [{:set, "apple", "a1"}, metadata_mutation],
+                 "apple",
+                 {Version.zero(), [{"zebra", "zebra" <> <<0>>}]}
+               )
+             )
+
+    # Drive more batches so any (incorrect) accumulation would be confirmed
+    # and distributed.
+    for i <- 1..5 do
+      commit!(proxy, epoch, encode_tx([{:set, "carrot_#{i}", "c"}], "carrot_#{i}"))
+    end
+
+    Process.sleep(100)
+
+    refute metadata_mutation in resolver_metadata_mutations(resolver_a)
+    refute metadata_mutation in resolver_metadata_mutations(resolver_b)
+    assert proxy_metadata(proxy).shards == %{}
+  end
+
+  test "metadata from committed transactions is distributed to resolver windows and proxy metadata", %{
+    proxy: proxy,
+    resolver_a: resolver_a,
+    resolver_b: resolver_b,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("q")
+    metadata_mutation = {:set, shard_key, Values.encode_shard_key_entry(3, "")}
+
+    version = commit!(proxy, epoch, encode_tx([metadata_mutation], "apple"))
+
+    # The proxy's structured metadata converges on the committed value...
+    commit_until(proxy, epoch, fn -> proxy_metadata(proxy).shards == %{"q" => 3} end)
+
+    # ...and each resolver's window holds the entry at the ORIGINAL commit
+    # version (ordering is preserved by version, not by confirmation arrival).
+    for resolver <- [resolver_a, resolver_b] do
+      entries = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
+      assert {^version, [^metadata_mutation]} = List.keyfind(entries, version, 0)
+    end
+  end
+
+  test "a mixed workload distributes only committed metadata, in version order", %{
+    proxy: proxy,
+    resolver_a: resolver_a,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("q")
+    set_tag = fn tag -> {:set, shard_key, Values.encode_shard_key_entry(tag, "")} end
+
+    # Conflict anchor in resolver_b's shard.
+    commit!(proxy, epoch, encode_tx([{:set, "zebra", "z1"}], "zebra"))
+
+    # Committed metadata (tag 1).
+    v1 = commit!(proxy, epoch, encode_tx([set_tag.(1)], "apple"))
+
+    # Globally-aborted metadata (tag 2): aborted by resolver_b's shard only.
+    assert {:error, :aborted} =
+             commit(
+               proxy,
+               epoch,
+               encode_tx([set_tag.(2)], "apple", {Version.zero(), [{"zebra", "zebra" <> <<0>>}]})
+             )
+
+    # Committed metadata (tag 3).
+    v3 = commit!(proxy, epoch, encode_tx([set_tag.(3)], "apple"))
+
+    # Later committed value wins; the aborted tag 2 never surfaces.
+    commit_until(proxy, epoch, fn -> proxy_metadata(proxy).shards == %{"q" => 3} end)
+    assert %Metadata{shards: %{"q" => 3}} = proxy_metadata(proxy)
+
+    # The resolver window carries exactly the committed entries, in version order.
+    commit_until(proxy, epoch, fn ->
+      versions =
+        resolver_a
+        |> :sys.get_state()
+        |> Map.fetch!(:metadata_window)
+        |> MetadataAccumulator.entries()
+        |> Enum.map(&elem(&1, 0))
+
+      v1 in versions and v3 in versions
+    end)
+
+    entries = MetadataAccumulator.entries(:sys.get_state(resolver_a).metadata_window)
+    metadata_entries = for {v, muts} <- entries, v in [v1, v3], do: {v, muts}
+    assert [{^v1, [tag1_mutation]}, {^v3, [tag3_mutation]}] = metadata_entries
+    assert tag1_mutation == set_tag.(1)
+    assert tag3_mutation == set_tag.(3)
+
+    refute set_tag.(2) in resolver_metadata_mutations(resolver_a)
+  end
+end

--- a/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
@@ -60,12 +60,20 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
 
   # Resolve from a fresh pid, exactly like a commit proxy finalization task
   # does - the metadata_ack carries the stable proxy identity, not this pid.
-  defp resolve_from_fresh_task(resolver, last_v, next_v, key, metadata, ack) do
+  defp resolve_from_fresh_task(resolver, last_v, next_v, key, metadata, ack, extra_opts \\ []) do
     parent = self()
 
     spawn_link(fn ->
       result =
-        Resolver.resolve_transactions(resolver, 1, last_v, next_v, [encode_tx(key)], [metadata], metadata_ack: ack)
+        Resolver.resolve_transactions(
+          resolver,
+          1,
+          last_v,
+          next_v,
+          [encode_tx(key)],
+          [metadata],
+          [metadata_ack: ack] ++ extra_opts
+        )
 
       send(parent, {:resolved, result})
     end)
@@ -237,6 +245,131 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     # discarded, so it missed NOTHING - it must get a plain (empty)
     # differential, not a gap-marked window that would force a full recovery.
     assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(3100), v(3200), "k5", [], {proxy_b, v(1)})
+  end
+
+  describe "deferred metadata (sharded mode, bedrock-q67.17)" do
+    test "a held batch caps the window; the confirmation releases it at the original commit version", %{
+      proxy: proxy,
+      m1: m1
+    } do
+      resolver = start_resolver()
+
+      # Sharded batch carrying metadata: no metadata_per_tx, hold the version.
+      # While a hold is outstanding the window is returned (never nil) so the
+      # settled cap reaches the proxy's merge, but it never extends to (or
+      # past) the held version.
+      assert {:ok, [], {nil, to0, []}} =
+               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
+
+      assert to0 == v(0)
+
+      assert {:ok, [], {nil, to0b, []}} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil})
+      assert to0b == v(0)
+
+      # The confirmation (already filtered by the proxy's merged global abort
+      # set) folds in at the ORIGINAL commit version and rides the reply.
+      assert {:ok, [], {nil, to, [{entry_version, [^m1]}]}} =
+               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
+
+      assert {to, entry_version} == {v(3), v(1)}
+      assert :sys.get_state(resolver).held_metadata_versions == MapSet.new()
+    end
+
+    test "a confirmation of an all-aborted batch clears the hold and advances the window with no entries", %{
+      proxy: proxy
+    } do
+      resolver = start_resolver()
+
+      assert {:ok, [], {nil, _, []}} =
+               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
+
+      # Every metadata-carrying transaction in the batch was globally aborted:
+      # the confirmation carries no mutations, but the reply still carries a
+      # window so the proxy's ack advances and it stops re-sending.
+      assert {:ok, [], {nil, to, []}} =
+               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil}, metadata_confirms: [{v(1), []}])
+
+      assert to == v(2)
+      assert MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window) == []
+    end
+
+    test "re-sent confirmations are idempotent", %{proxy: proxy, m1: m1} do
+      resolver = start_resolver()
+
+      assert {:ok, [], {nil, _, []}} =
+               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
+
+      assert {:ok, [], {nil, _, [{_, [^m1]}]}} =
+               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
+
+      # The proxy re-sends until its ack covers v(1); no duplicate entry.
+      assert {:ok, [], _} =
+               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
+
+      assert [{entry_version, [^m1]}] = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
+      assert entry_version == v(1)
+    end
+
+    test "out-of-order confirmations from different proxies keep entries in version order and withheld until settled",
+         %{m1: m1, m2: m2} do
+      resolver = start_resolver()
+      proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
+      proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+      # proxy_a holds v(1); proxy_b holds v(2).
+      assert {:ok, [], {nil, _, []}} =
+               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy_a, nil}, metadata_hold: true)
+
+      assert {:ok, [], {nil, _, []}} =
+               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy_b, nil}, metadata_hold: true)
+
+      # proxy_b confirms v(2) FIRST - but v(1) is still held, so the entry at
+      # v(2) is withheld (no proxy may apply or ack past unsettled metadata).
+      assert {:ok, [], {nil, to_b, []}} =
+               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy_b, nil},
+                 metadata_confirms: [{v(2), [m2]}]
+               )
+
+      assert to_b == v(0)
+
+      # proxy_a confirms v(1): everything settles and both entries are served
+      # in ORIGINAL version order.
+      assert {:ok, [], {nil, to, [{e1, [^m1]}, {e2, [^m2]}]}} =
+               resolve_from_fresh_task(resolver, v(3), v(4), "k4", [], {proxy_a, nil},
+                 metadata_confirms: [{v(1), [m1]}]
+               )
+
+      assert {to, e1, e2} == {v(4), v(1), v(2)}
+    end
+
+    test "held versions never confirmed (dead proxy) expire into a coverage gap, not silent loss", %{
+      proxy: proxy,
+      m1: m1
+    } do
+      # 1ms retention = 1000 versions.
+      resolver = start_resolver(version_retention_ms: 1)
+
+      assert {:ok, [], {nil, _, []}} =
+               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
+
+      # The submitting proxy never confirms v(1) (it died mid-batch, or
+      # stalled beyond any healthy cadence). Once the held version falls out
+      # of the retention horizon it expires - but the metadata MAY have
+      # committed, so the expired version poisons the pruned floor: proxies
+      # acked below it (necessarily all of them - holds cap acks) receive a
+      # gap-marked window (from_version above their applied version) and take
+      # the fail-fast exit into recovery rather than silently missing it.
+      assert {:ok, [], {from, to, []}} = resolve_from_fresh_task(resolver, v(1), v(2500), "k2", [], {proxy, nil})
+      assert {from, to} == {v(1), v(2500)}
+      assert :sys.get_state(resolver).held_metadata_versions == MapSet.new()
+
+      # A proxy acked at or above the poisoned floor is served normally
+      # (single-mode accumulation here just proves the cap is gone).
+      assert {:ok, [], {_, to, [{entry_version, [^m1]}]}} =
+               resolve_from_fresh_task(resolver, v(2500), v(2600), "k3", [m1], {proxy, v(2500)})
+
+      assert {to, entry_version} == {v(2600), v(2600)}
+    end
   end
 
   test "proxies not seen within version retention expire; a returning laggard gets a gap-marked window", %{

--- a/test/bedrock/data_plane/resolver/server_test.exs
+++ b/test/bedrock/data_plane/resolver/server_test.exs
@@ -313,7 +313,7 @@ defmodule Bedrock.DataPlane.Resolver.ServerTest do
       wait_until(fn -> map_size(:sys.get_state(server).waiting) == 1 end)
       state = :sys.get_state(server)
 
-      assert [{deadline, _reply_fn, {^future_version, [^test_transaction], [[]], _proxy_pid}}] =
+      assert [{deadline, _reply_fn, {^future_version, [^test_transaction], [[]], _proxy_pid, _metadata_directives}}] =
                Map.get(state.waiting, next_version)
 
       assert is_integer(deadline)

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -47,7 +47,7 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
     def handle_call(
           {:resolve_transactions, _epoch, {_last_version, _commit_version}, _transaction_summaries, _metadata_per_tx,
-           {_proxy_id, _acked_version}},
+           {_proxy_id, _acked_version}, {_metadata_hold?, _metadata_confirms}},
           _from,
           state
         ) do


### PR DESCRIPTION
Fixes bedrock-q67.17 (from PR #106 gating audit): in sharded-resolver mode, abort sets are per-resolver at accumulation time, so a transaction aborted by only ONE shard's resolver still had its metadata accumulated by the OTHER resolvers and distributed to proxies. Blocking for q67.9 (shard map over system keys).

## Design

**Chosen: (a) deferred accumulation via next-call piggyback**, with the candidate storage on the proxy side (it already holds `metadata_per_tx` and is the only party that ever knows the merged global abort set):

- Sharded proxies send **no** `metadata_per_tx` to resolvers. The resolve call instead carries two new opts, piggybacked alongside `metadata_ack`:
  - `metadata_hold: true` when the batch carries metadata — each resolver marks the batch version *held* and never extends a window to (or past) the oldest held version (`settled_version`), so no proxy can apply or ack past metadata that may still be confirmed;
  - `metadata_confirms: [{version, mutations}]` — committed metadata from earlier held batches, already filtered by the merged **global** abort set, folded into the accumulator at the **original commit versions** (sorted insert; confirmations may arrive out of order across proxies, but the settled cap guarantees no ack ever passed them).
- After merging abort sets, the finalization task reports `{commit_version, globally_committed_metadata}` to the proxy server (`metadata_deferred_fn`), which re-sends it as a confirmation on **every** subsequent resolver call (confirms are idempotent: only still-held versions apply) until resolver windows ack past it. Liveness rides the existing empty-batch cadence.
- `merge_metadata_windows` now claims the weakest coverage on both ends — `max(from)` (unchanged) and `min(to)` — deduplicates identical entries by version, and truncates entries beyond the merged `to`. A resolver returns `nil` only when its settled floor has reached its `last_version`, so `nil` replies never mask a lower settled floor.
- A held version that expires unconfirmed (proxy dead/stalled past the retention horizon) is **not** silently dropped: it poisons `metadata_pruned_through`, so every proxy (all acked below it, since holds cap acks) takes the existing coverage-gap fail-fast exit into director-driven recovery, which rebuilds metadata from durable state.

**Rejected (b) explicit confirm round-trip** — an extra blocking call per metadata batch buys nothing over the piggyback: confirmation latency is bounded by the next batch/empty-batch cadence, and metadata batches are rare.

**Rejected (c) single-resolver metadata pinning** — routing all `\xFF` conflicts to one resolver does not fix the bug: the pinned resolver still cannot see aborts decided by *other* shards' resolvers for transactions that carry metadata plus cross-shard conflicts. (A designated metadata-*hub* resolver combined with the hold/confirm protocol would work and would delete the window-merge machinery; noted as a possible future simplification, but it is a larger departure from the q67.16 all-resolver window design than this ticket needs.)

## Lag / visibility analysis

- **Proxy-local (same-batch)**: unchanged. The submitting proxy applies its own batch's globally-committed metadata to that batch's routing data immediately (`local_entries`), exactly matching the pre-change behavior where the resolver window included the batch's own metadata. Structured `Metadata` state is fed strictly by resolver windows to keep ack semantics intact.
- **Resolver windows / other proxies**: lag one confirmation round-trip (≤ one batch interval or the empty-batch cadence). Other proxies always lagged by one window fetch before this change; the added lag is the confirm leg only. Nothing in RoutingData/Metadata requires cross-proxy same-batch visibility.
- **Ordering**: entries enter accumulators at original commit versions; windows never extend past unsettled versions, so proxies always apply metadata in commit-version order even when confirmations arrive out of order.
- **Single-resolver mode**: byte-for-byte current behavior and latency — `metadata_per_tx` still accumulates at resolution, holds/confirms are never sent, `settled == last_version` so window shapes and the `nil` rule are unchanged.

## TDD

Failing test first (`sharded_metadata_distribution_integration_test.exs`, two real resolvers + real sequencer/proxy): metadata from a transaction aborted only by shard B's resolver leaked through shard A's accumulator into proxy metadata — red on the old code, green after. Plus: committed metadata still distributes to all resolver windows at the original version; a mixed committed/aborted workload preserves version order; existing #105/#106 single-resolver integration tests unchanged. Protocol-level coverage added in `metadata_window_distribution_test.exs` (hold caps, out-of-order confirms, idempotence, expiry-poisoning) and `sharded_resolution_and_edge_cases_test.exs` (no speculative metadata to resolvers, global-abort filtering via `metadata_deferred_fn`, weakest-coverage merge).

## Gating audit

8-angle review run before landing; fixed from it: deprecated `Tuple.append` (CI warnings-as-errors), empty-batch stale-retry `0..-1` range crash, silent metadata loss on held-version expiry (now gap-poisons into recovery), `nil`-window bypass of the `min(to)` cap, info-message cancellation of the open-batch flush timeout (`noreply_resuming_cadence`), stale 6-tuple fake in `finalization_test_support.ex`, duplicate committed-metadata filter (shared `MetadataAccumulator.committed_mutations/2`), window-merge dedup, and several simplifications (hold/accumulate exclusivity in one branch, constant param removal, combined retention expiry). Known accepted trade-offs: confirms re-broadcast to all resolvers until the slowest settles (bounded, rare); duplicated integration-test setup mirrors the existing single-resolver file (candidate for a shared fixture ticket).

Suites: resolver + commit_proxy + control_plane at 2 seeds, full suite at 2 seeds — green. `mix format`, `credo --strict`, `dialyzer` clean.
